### PR TITLE
Add comprehensive unit tests for Trade360SDK.Common.Entities

### DIFF
--- a/test/Trade360SDK.Common.Entities.Tests/Attributes/Trade360EntityAttributeTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Attributes/Trade360EntityAttributeTests.cs
@@ -1,21 +1,208 @@
-using Trade360SDK.Common.Attributes;
+using System;
+using FluentAssertions;
 using Xunit;
+using Trade360SDK.Common.Attributes;
 
 namespace Trade360SDK.Common.Entities.Tests.Attributes
 {
     public class Trade360EntityAttributeTests
     {
         [Fact]
-        public void Constructor_SetsEntityKey()
+        public void Trade360EntityAttribute_Constructor_ShouldSetEntityKey()
         {
             // Arrange
-            int expectedKey = 42;
+            var entityKey = 42;
 
             // Act
-            var attribute = new Trade360EntityAttribute(expectedKey);
+            var attribute = new Trade360EntityAttribute(entityKey);
 
             // Assert
-            Assert.Equal(expectedKey, attribute.EntityKey);
+            attribute.Should().NotBeNull();
+            attribute.EntityKey.Should().Be(entityKey);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MinValue)]
+        [InlineData(999)]
+        [InlineData(12345)]
+        public void Trade360EntityAttribute_Constructor_WithVariousEntityKeys_ShouldSetValue(int entityKey)
+        {
+            // Act
+            var attribute = new Trade360EntityAttribute(entityKey);
+
+            // Assert
+            attribute.EntityKey.Should().Be(entityKey);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_EntityKey_ShouldBeReadOnly()
+        {
+            // Arrange
+            var entityKey = 123;
+            var attribute = new Trade360EntityAttribute(entityKey);
+
+            // Act & Assert
+            // EntityKey should not have a setter - this test verifies it's read-only
+            attribute.EntityKey.Should().Be(entityKey);
+            
+            // Verify we can't change it (compilation test)
+            var originalKey = attribute.EntityKey;
+            attribute.EntityKey.Should().Be(originalKey);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_ShouldInheritFromAttribute()
+        {
+            // Arrange & Act
+            var attribute = new Trade360EntityAttribute(1);
+
+            // Assert
+            attribute.Should().BeAssignableTo<Attribute>();
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_ShouldHaveCorrectAttributeUsage()
+        {
+            // Arrange
+            var attributeType = typeof(Trade360EntityAttribute);
+
+            // Act
+            var attributeUsage = (AttributeUsageAttribute)Attribute.GetCustomAttribute(attributeType, typeof(AttributeUsageAttribute));
+
+            // Assert
+            attributeUsage.Should().NotBeNull();
+            attributeUsage.ValidOn.Should().HaveFlag(AttributeTargets.Class);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_MultipleInstances_ShouldHaveIndependentEntityKeys()
+        {
+            // Arrange & Act
+            var attribute1 = new Trade360EntityAttribute(100);
+            var attribute2 = new Trade360EntityAttribute(200);
+            var attribute3 = new Trade360EntityAttribute(300);
+
+            // Assert
+            attribute1.EntityKey.Should().Be(100);
+            attribute2.EntityKey.Should().Be(200);
+            attribute3.EntityKey.Should().Be(300);
+            
+            attribute1.EntityKey.Should().NotBe(attribute2.EntityKey);
+            attribute2.EntityKey.Should().NotBe(attribute3.EntityKey);
+            attribute1.EntityKey.Should().NotBe(attribute3.EntityKey);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_ToString_ShouldReturnStringRepresentation()
+        {
+            // Arrange
+            var entityKey = 456;
+            var attribute = new Trade360EntityAttribute(entityKey);
+
+            // Act
+            var result = attribute.ToString();
+
+            // Assert
+            result.Should().NotBeNullOrEmpty();
+            // Should contain the class name
+            result.Should().Contain("Trade360EntityAttribute");
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_GetHashCode_ShouldReturnConsistentValue()
+        {
+            // Arrange
+            var entityKey = 789;
+            var attribute = new Trade360EntityAttribute(entityKey);
+
+            // Act
+            var hashCode1 = attribute.GetHashCode();
+            var hashCode2 = attribute.GetHashCode();
+
+            // Assert
+            hashCode1.Should().Be(hashCode2);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_Equals_WithSameEntityKey_ShouldBeEqual()
+        {
+            // Arrange
+            var entityKey = 555;
+            var attribute1 = new Trade360EntityAttribute(entityKey);
+            var attribute2 = new Trade360EntityAttribute(entityKey);
+
+            // Act & Assert
+            // Note: This tests reference equality since Attribute doesn't override Equals by default
+            attribute1.Should().NotBeSameAs(attribute2);
+            attribute1.EntityKey.Should().Be(attribute2.EntityKey);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_Type_ShouldBeCorrect()
+        {
+            // Arrange & Act
+            var attribute = new Trade360EntityAttribute(1);
+
+            // Assert
+            attribute.GetType().Should().Be(typeof(Trade360EntityAttribute));
+            attribute.GetType().Name.Should().Be("Trade360EntityAttribute");
+        }
+    }
+
+    // Test class to verify the attribute can be applied to classes
+    [Trade360EntityAttribute(999)]
+    public class TestEntityWithAttribute
+    {
+        public string Name { get; set; }
+    }
+
+    public class Trade360EntityAttributeUsageTests
+    {
+        [Fact]
+        public void Trade360EntityAttribute_CanBeAppliedToClass_ShouldWork()
+        {
+            // Arrange
+            var type = typeof(TestEntityWithAttribute);
+
+            // Act
+            var attributes = type.GetCustomAttributes(typeof(Trade360EntityAttribute), false);
+
+            // Assert
+            attributes.Should().HaveCount(1);
+            var attribute = attributes[0] as Trade360EntityAttribute;
+            attribute.Should().NotBeNull();
+            attribute.EntityKey.Should().Be(999);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_AppliedToClass_ShouldBeRetrievable()
+        {
+            // Arrange
+            var type = typeof(TestEntityWithAttribute);
+
+            // Act
+            var attribute = Attribute.GetCustomAttribute(type, typeof(Trade360EntityAttribute)) as Trade360EntityAttribute;
+
+            // Assert
+            attribute.Should().NotBeNull();
+            attribute.EntityKey.Should().Be(999);
+        }
+
+        [Fact]
+        public void Trade360EntityAttribute_ClassWithoutAttribute_ShouldReturnNull()
+        {
+            // Arrange
+            var type = typeof(Trade360EntityAttributeTests);
+
+            // Act
+            var attribute = Attribute.GetCustomAttribute(type, typeof(Trade360EntityAttribute)) as Trade360EntityAttribute;
+
+            // Assert
+            attribute.Should().BeNull();
         }
     }
 } 

--- a/test/Trade360SDK.Common.Entities.Tests/Configuration/Trade360SettingsTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Configuration/Trade360SettingsTests.cs
@@ -1,0 +1,373 @@
+using System;
+using FluentAssertions;
+using Xunit;
+using Trade360SDK.Common.Configuration;
+
+namespace Trade360SDK.Common.Entities.Tests.Configuration
+{
+    public class Trade360SettingsTests
+    {
+        [Fact]
+        public void Trade360Settings_DefaultConstructor_ShouldCreateInstanceWithNullProperties()
+        {
+            // Act
+            var settings = new Trade360Settings();
+
+            // Assert
+            settings.Should().NotBeNull();
+            settings.CustomersApiBaseUrl.Should().BeNull();
+            settings.SnapshotApiBaseUrl.Should().BeNull();
+            settings.InplayPackageCredentials.Should().BeNull();
+            settings.PrematchPackageCredentials.Should().BeNull();
+        }
+
+        [Fact]
+        public void Trade360Settings_SetCustomersApiBaseUrl_ShouldSetValue()
+        {
+            // Arrange
+            var settings = new Trade360Settings();
+            var baseUrl = "https://api.customers.example.com";
+
+            // Act
+            settings.CustomersApiBaseUrl = baseUrl;
+
+            // Assert
+            settings.CustomersApiBaseUrl.Should().Be(baseUrl);
+        }
+
+        [Fact]
+        public void Trade360Settings_SetSnapshotApiBaseUrl_ShouldSetValue()
+        {
+            // Arrange
+            var settings = new Trade360Settings();
+            var baseUrl = "https://api.snapshot.example.com";
+
+            // Act
+            settings.SnapshotApiBaseUrl = baseUrl;
+
+            // Assert
+            settings.SnapshotApiBaseUrl.Should().Be(baseUrl);
+        }
+
+        [Fact]
+        public void Trade360Settings_SetInplayPackageCredentials_ShouldSetValue()
+        {
+            // Arrange
+            var settings = new Trade360Settings();
+            var credentials = new PackageCredentials
+            {
+                PackageId = 123,
+                Username = "inplay-user",
+                Password = "inplay-pass"
+            };
+
+            // Act
+            settings.InplayPackageCredentials = credentials;
+
+            // Assert
+            settings.InplayPackageCredentials.Should().Be(credentials);
+            settings.InplayPackageCredentials.PackageId.Should().Be(123);
+            settings.InplayPackageCredentials.Username.Should().Be("inplay-user");
+            settings.InplayPackageCredentials.Password.Should().Be("inplay-pass");
+        }
+
+        [Fact]
+        public void Trade360Settings_SetPrematchPackageCredentials_ShouldSetValue()
+        {
+            // Arrange
+            var settings = new Trade360Settings();
+            var credentials = new PackageCredentials
+            {
+                PackageId = 456,
+                Username = "prematch-user",
+                Password = "prematch-pass"
+            };
+
+            // Act
+            settings.PrematchPackageCredentials = credentials;
+
+            // Assert
+            settings.PrematchPackageCredentials.Should().Be(credentials);
+            settings.PrematchPackageCredentials.PackageId.Should().Be(456);
+            settings.PrematchPackageCredentials.Username.Should().Be("prematch-user");
+            settings.PrematchPackageCredentials.Password.Should().Be("prematch-pass");
+        }
+
+        [Fact]
+        public void Trade360Settings_SetAllProperties_ShouldSetAllValues()
+        {
+            // Arrange
+            var settings = new Trade360Settings();
+            var customersApiUrl = "https://api.customers.example.com";
+            var snapshotApiUrl = "https://api.snapshot.example.com";
+            var inplayCredentials = new PackageCredentials { PackageId = 123, Username = "inplay", Password = "pass1" };
+            var prematchCredentials = new PackageCredentials { PackageId = 456, Username = "prematch", Password = "pass2" };
+
+            // Act
+            settings.CustomersApiBaseUrl = customersApiUrl;
+            settings.SnapshotApiBaseUrl = snapshotApiUrl;
+            settings.InplayPackageCredentials = inplayCredentials;
+            settings.PrematchPackageCredentials = prematchCredentials;
+
+            // Assert
+            settings.CustomersApiBaseUrl.Should().Be(customersApiUrl);
+            settings.SnapshotApiBaseUrl.Should().Be(snapshotApiUrl);
+            settings.InplayPackageCredentials.Should().Be(inplayCredentials);
+            settings.PrematchPackageCredentials.Should().Be(prematchCredentials);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("https://api.test.com")]
+        [InlineData("http://localhost:8080")]
+        [InlineData("https://api.example.com/v1/")]
+        public void Trade360Settings_SetVariousUrls_ShouldSetValues(string url)
+        {
+            // Arrange
+            var settings = new Trade360Settings();
+
+            // Act
+            settings.CustomersApiBaseUrl = url;
+            settings.SnapshotApiBaseUrl = url;
+
+            // Assert
+            settings.CustomersApiBaseUrl.Should().Be(url);
+            settings.SnapshotApiBaseUrl.Should().Be(url);
+        }
+
+        [Fact]
+        public void Trade360Settings_PropertySettersGetters_ShouldWorkCorrectly()
+        {
+            // Arrange
+            var settings = new Trade360Settings();
+
+            // Act & Assert - Test that we can set and get each property multiple times
+            settings.CustomersApiBaseUrl = "url1";
+            settings.CustomersApiBaseUrl.Should().Be("url1");
+            settings.CustomersApiBaseUrl = "url2";
+            settings.CustomersApiBaseUrl.Should().Be("url2");
+
+            settings.SnapshotApiBaseUrl = "snapshot1";
+            settings.SnapshotApiBaseUrl.Should().Be("snapshot1");
+            settings.SnapshotApiBaseUrl = null;
+            settings.SnapshotApiBaseUrl.Should().BeNull();
+        }
+    }
+
+    public class PackageCredentialsTests
+    {
+        [Fact]
+        public void PackageCredentials_DefaultConstructor_ShouldCreateInstanceWithDefaultValues()
+        {
+            // Act
+            var credentials = new PackageCredentials();
+
+            // Assert
+            credentials.Should().NotBeNull();
+            credentials.PackageId.Should().Be(0);
+            credentials.Username.Should().BeNull();
+            credentials.Password.Should().BeNull();
+            credentials.MessageFormat.Should().Be("json");
+        }
+
+        [Fact]
+        public void PackageCredentials_SetPackageId_ShouldSetValue()
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+            var packageId = 12345;
+
+            // Act
+            credentials.PackageId = packageId;
+
+            // Assert
+            credentials.PackageId.Should().Be(packageId);
+        }
+
+        [Fact]
+        public void PackageCredentials_SetUsername_ShouldSetValue()
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+            var username = "test-user";
+
+            // Act
+            credentials.Username = username;
+
+            // Assert
+            credentials.Username.Should().Be(username);
+        }
+
+        [Fact]
+        public void PackageCredentials_SetPassword_ShouldSetValue()
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+            var password = "test-password";
+
+            // Act
+            credentials.Password = password;
+
+            // Assert
+            credentials.Password.Should().Be(password);
+        }
+
+        [Fact]
+        public void PackageCredentials_SetMessageFormat_ShouldSetValue()
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+            var messageFormat = "xml";
+
+            // Act
+            credentials.MessageFormat = messageFormat;
+
+            // Assert
+            credentials.MessageFormat.Should().Be(messageFormat);
+        }
+
+        [Fact]
+        public void PackageCredentials_SetAllProperties_ShouldSetAllValues()
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+            var packageId = 999;
+            var username = "admin";
+            var password = "secret123";
+            var messageFormat = "protobuf";
+
+            // Act
+            credentials.PackageId = packageId;
+            credentials.Username = username;
+            credentials.Password = password;
+            credentials.MessageFormat = messageFormat;
+
+            // Assert
+            credentials.PackageId.Should().Be(packageId);
+            credentials.Username.Should().Be(username);
+            credentials.Password.Should().Be(password);
+            credentials.MessageFormat.Should().Be(messageFormat);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(1)]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MinValue)]
+        public void PackageCredentials_SetVariousPackageIds_ShouldSetValue(int packageId)
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+
+            // Act
+            credentials.PackageId = packageId;
+
+            // Assert
+            credentials.PackageId.Should().Be(packageId);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("user")]
+        [InlineData("very-long-username-with-special-characters@domain.com")]
+        public void PackageCredentials_SetVariousUsernames_ShouldSetValue(string username)
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+
+            // Act
+            credentials.Username = username;
+
+            // Assert
+            credentials.Username.Should().Be(username);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("pass")]
+        [InlineData("very-long-password-with-special-characters!@#$%^&*()")]
+        public void PackageCredentials_SetVariousPasswords_ShouldSetValue(string password)
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+
+            // Act
+            credentials.Password = password;
+
+            // Assert
+            credentials.Password.Should().Be(password);
+        }
+
+        [Theory]
+        [InlineData("json")]
+        [InlineData("xml")]
+        [InlineData("protobuf")]
+        [InlineData("binary")]
+        [InlineData("")]
+        public void PackageCredentials_SetVariousMessageFormats_ShouldSetValue(string messageFormat)
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+
+            // Act
+            credentials.MessageFormat = messageFormat;
+
+            // Assert
+            credentials.MessageFormat.Should().Be(messageFormat);
+        }
+
+        [Fact]
+        public void PackageCredentials_PropertySettersGetters_ShouldWorkCorrectly()
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+
+            // Act & Assert - Test that we can set and get each property multiple times
+            credentials.Username = "user1";
+            credentials.Username.Should().Be("user1");
+            credentials.Username = "user2";
+            credentials.Username.Should().Be("user2");
+            credentials.Username = null;
+            credentials.Username.Should().BeNull();
+
+            credentials.PackageId = 100;
+            credentials.PackageId.Should().Be(100);
+            credentials.PackageId = 200;
+            credentials.PackageId.Should().Be(200);
+
+            credentials.MessageFormat = "xml";
+            credentials.MessageFormat.Should().Be("xml");
+            credentials.MessageFormat = "json";
+            credentials.MessageFormat.Should().Be("json");
+        }
+
+        [Fact]
+        public void PackageCredentials_DefaultMessageFormat_ShouldBeJson()
+        {
+            // Act
+            var credentials = new PackageCredentials();
+
+            // Assert
+            credentials.MessageFormat.Should().Be("json");
+        }
+
+        [Fact]
+        public void PackageCredentials_NullStringValues_ShouldSetNulls()
+        {
+            // Arrange
+            var credentials = new PackageCredentials();
+
+            // Act
+            credentials.Username = null;
+            credentials.Password = null;
+
+            // Assert
+            credentials.Username.Should().BeNull();
+            credentials.Password.Should().BeNull();
+        }
+    }
+} 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Enums/EnumComprehensiveTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Enums/EnumComprehensiveTests.cs
@@ -1,0 +1,385 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+using Trade360SDK.Common.Entities.Enums;
+
+namespace Trade360SDK.Common.Entities.Tests.Entities.Enums
+{
+    public class FixtureStatusEnumTests
+    {
+        [Fact]
+        public void FixtureStatus_ShouldHaveCorrectValues()
+        {
+            // Assert
+            ((int)FixtureStatus.NotSet).Should().Be(0);
+            ((int)FixtureStatus.NSY).Should().Be(1);
+            ((int)FixtureStatus.InProgress).Should().Be(2);
+            ((int)FixtureStatus.Finished).Should().Be(3);
+            ((int)FixtureStatus.Cancelled).Should().Be(4);
+            ((int)FixtureStatus.Postponed).Should().Be(5);
+            ((int)FixtureStatus.Interrupted).Should().Be(6);
+            ((int)FixtureStatus.Abandoned).Should().Be(7);
+            ((int)FixtureStatus.LostCoverage).Should().Be(8);
+            ((int)FixtureStatus.AboutToStart).Should().Be(9);
+        }
+
+        [Theory]
+        [InlineData(FixtureStatus.NotSet, 0)]
+        [InlineData(FixtureStatus.NSY, 1)]
+        [InlineData(FixtureStatus.InProgress, 2)]
+        [InlineData(FixtureStatus.Finished, 3)]
+        [InlineData(FixtureStatus.Cancelled, 4)]
+        [InlineData(FixtureStatus.Postponed, 5)]
+        [InlineData(FixtureStatus.Interrupted, 6)]
+        [InlineData(FixtureStatus.Abandoned, 7)]
+        [InlineData(FixtureStatus.LostCoverage, 8)]
+        [InlineData(FixtureStatus.AboutToStart, 9)]
+        public void FixtureStatus_CastToInt_ShouldReturnCorrectValue(FixtureStatus status, int expectedValue)
+        {
+            // Act
+            var intValue = (int)status;
+
+            // Assert
+            intValue.Should().Be(expectedValue);
+        }
+
+        [Theory]
+        [InlineData(0, FixtureStatus.NotSet)]
+        [InlineData(1, FixtureStatus.NSY)]
+        [InlineData(2, FixtureStatus.InProgress)]
+        [InlineData(3, FixtureStatus.Finished)]
+        [InlineData(4, FixtureStatus.Cancelled)]
+        [InlineData(5, FixtureStatus.Postponed)]
+        [InlineData(6, FixtureStatus.Interrupted)]
+        [InlineData(7, FixtureStatus.Abandoned)]
+        [InlineData(8, FixtureStatus.LostCoverage)]
+        [InlineData(9, FixtureStatus.AboutToStart)]
+        public void FixtureStatus_CastFromInt_ShouldReturnCorrectEnum(int intValue, FixtureStatus expectedStatus)
+        {
+            // Act
+            var status = (FixtureStatus)intValue;
+
+            // Assert
+            status.Should().Be(expectedStatus);
+        }
+
+        [Fact]
+        public void FixtureStatus_ToString_ShouldReturnEnumName()
+        {
+            // Act & Assert
+            FixtureStatus.NotSet.ToString().Should().Be("NotSet");
+            FixtureStatus.NSY.ToString().Should().Be("NSY");
+            FixtureStatus.InProgress.ToString().Should().Be("InProgress");
+            FixtureStatus.Finished.ToString().Should().Be("Finished");
+            FixtureStatus.Cancelled.ToString().Should().Be("Cancelled");
+            FixtureStatus.Postponed.ToString().Should().Be("Postponed");
+            FixtureStatus.Interrupted.ToString().Should().Be("Interrupted");
+            FixtureStatus.Abandoned.ToString().Should().Be("Abandoned");
+            FixtureStatus.LostCoverage.ToString().Should().Be("LostCoverage");
+            FixtureStatus.AboutToStart.ToString().Should().Be("AboutToStart");
+        }
+
+        [Fact]
+        public void FixtureStatus_GetValues_ShouldReturnAllValues()
+        {
+            // Act
+            var values = Enum.GetValues<FixtureStatus>();
+
+            // Assert
+            values.Should().HaveCount(10);
+            values.Should().Contain(FixtureStatus.NotSet);
+            values.Should().Contain(FixtureStatus.NSY);
+            values.Should().Contain(FixtureStatus.InProgress);
+            values.Should().Contain(FixtureStatus.Finished);
+            values.Should().Contain(FixtureStatus.Cancelled);
+            values.Should().Contain(FixtureStatus.Postponed);
+            values.Should().Contain(FixtureStatus.Interrupted);
+            values.Should().Contain(FixtureStatus.Abandoned);
+            values.Should().Contain(FixtureStatus.LostCoverage);
+            values.Should().Contain(FixtureStatus.AboutToStart);
+        }
+
+        [Fact]
+        public void FixtureStatus_IsDefined_ShouldReturnCorrectResult()
+        {
+            // Act & Assert
+            Enum.IsDefined(typeof(FixtureStatus), 0).Should().BeTrue();
+            Enum.IsDefined(typeof(FixtureStatus), 9).Should().BeTrue();
+            Enum.IsDefined(typeof(FixtureStatus), 10).Should().BeFalse();
+            Enum.IsDefined(typeof(FixtureStatus), -1).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("NotSet", FixtureStatus.NotSet)]
+        [InlineData("NSY", FixtureStatus.NSY)]
+        [InlineData("InProgress", FixtureStatus.InProgress)]
+        [InlineData("Finished", FixtureStatus.Finished)]
+        [InlineData("Cancelled", FixtureStatus.Cancelled)]
+        [InlineData("Postponed", FixtureStatus.Postponed)]
+        [InlineData("Interrupted", FixtureStatus.Interrupted)]
+        [InlineData("Abandoned", FixtureStatus.Abandoned)]
+        [InlineData("LostCoverage", FixtureStatus.LostCoverage)]
+        [InlineData("AboutToStart", FixtureStatus.AboutToStart)]
+        public void FixtureStatus_Parse_ShouldReturnCorrectEnum(string enumString, FixtureStatus expectedStatus)
+        {
+            // Act
+            var status = Enum.Parse<FixtureStatus>(enumString);
+
+            // Assert
+            status.Should().Be(expectedStatus);
+        }
+    }
+
+    public class BetStatusEnumTests
+    {
+        [Fact]
+        public void BetStatus_ShouldHaveCorrectValues()
+        {
+            // Assert
+            ((int)BetStatus.NotSet).Should().Be(0);
+            ((int)BetStatus.Open).Should().Be(1);
+            ((int)BetStatus.Suspended).Should().Be(2);
+            ((int)BetStatus.Settled).Should().Be(3);
+        }
+
+        [Theory]
+        [InlineData(BetStatus.NotSet, 0)]
+        [InlineData(BetStatus.Open, 1)]
+        [InlineData(BetStatus.Suspended, 2)]
+        [InlineData(BetStatus.Settled, 3)]
+        public void BetStatus_CastToInt_ShouldReturnCorrectValue(BetStatus status, int expectedValue)
+        {
+            // Act
+            var intValue = (int)status;
+
+            // Assert
+            intValue.Should().Be(expectedValue);
+        }
+
+        [Theory]
+        [InlineData(0, BetStatus.NotSet)]
+        [InlineData(1, BetStatus.Open)]
+        [InlineData(2, BetStatus.Suspended)]
+        [InlineData(3, BetStatus.Settled)]
+        public void BetStatus_CastFromInt_ShouldReturnCorrectEnum(int intValue, BetStatus expectedStatus)
+        {
+            // Act
+            var status = (BetStatus)intValue;
+
+            // Assert
+            status.Should().Be(expectedStatus);
+        }
+
+        [Fact]
+        public void BetStatus_ToString_ShouldReturnEnumName()
+        {
+            // Act & Assert
+            BetStatus.NotSet.ToString().Should().Be("NotSet");
+            BetStatus.Open.ToString().Should().Be("Open");
+            BetStatus.Suspended.ToString().Should().Be("Suspended");
+            BetStatus.Settled.ToString().Should().Be("Settled");
+        }
+
+        [Fact]
+        public void BetStatus_GetValues_ShouldReturnAllValues()
+        {
+            // Act
+            var values = Enum.GetValues<BetStatus>();
+
+            // Assert
+            values.Should().HaveCount(4);
+            values.Should().Contain(BetStatus.NotSet);
+            values.Should().Contain(BetStatus.Open);
+            values.Should().Contain(BetStatus.Suspended);
+            values.Should().Contain(BetStatus.Settled);
+        }
+
+        [Fact]
+        public void BetStatus_IsDefined_ShouldReturnCorrectResult()
+        {
+            // Act & Assert
+            Enum.IsDefined(typeof(BetStatus), 0).Should().BeTrue();
+            Enum.IsDefined(typeof(BetStatus), 3).Should().BeTrue();
+            Enum.IsDefined(typeof(BetStatus), 4).Should().BeFalse();
+            Enum.IsDefined(typeof(BetStatus), -1).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("NotSet", BetStatus.NotSet)]
+        [InlineData("Open", BetStatus.Open)]
+        [InlineData("Suspended", BetStatus.Suspended)]
+        [InlineData("Settled", BetStatus.Settled)]
+        public void BetStatus_Parse_ShouldReturnCorrectEnum(string enumString, BetStatus expectedStatus)
+        {
+            // Act
+            var status = Enum.Parse<BetStatus>(enumString);
+
+            // Assert
+            status.Should().Be(expectedStatus);
+        }
+    }
+
+    public class SubscriptionStateEnumTests
+    {
+        [Fact]
+        public void SubscriptionState_ShouldHaveCorrectValues()
+        {
+            // Assert
+            ((int)SubscriptionState.All).Should().Be(0);
+            ((int)SubscriptionState.NotSubscribed).Should().Be(1);
+            ((int)SubscriptionState.Subscribed).Should().Be(2);
+        }
+
+        [Theory]
+        [InlineData(SubscriptionState.All, 0)]
+        [InlineData(SubscriptionState.NotSubscribed, 1)]
+        [InlineData(SubscriptionState.Subscribed, 2)]
+        public void SubscriptionState_CastToInt_ShouldReturnCorrectValue(SubscriptionState state, int expectedValue)
+        {
+            // Act
+            var intValue = (int)state;
+
+            // Assert
+            intValue.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void SubscriptionState_ToString_ShouldReturnEnumName()
+        {
+            // Act & Assert
+            SubscriptionState.All.ToString().Should().Be("All");
+            SubscriptionState.NotSubscribed.ToString().Should().Be("NotSubscribed");
+            SubscriptionState.Subscribed.ToString().Should().Be("Subscribed");
+        }
+
+        [Fact]
+        public void SubscriptionState_GetValues_ShouldReturnAllValues()
+        {
+            // Act
+            var values = Enum.GetValues<SubscriptionState>();
+
+            // Assert
+            values.Should().HaveCount(3);
+            values.Should().Contain(SubscriptionState.All);
+            values.Should().Contain(SubscriptionState.NotSubscribed);
+            values.Should().Contain(SubscriptionState.Subscribed);
+        }
+    }
+
+    public class DangerIndicatorStatusEnumTests
+    {
+        [Fact]
+        public void DangerIndicatorStatus_ShouldHaveCorrectValues()
+        {
+            // Assert
+            ((int)DangerIndicatorStatus.Safe).Should().Be(1);
+            ((int)DangerIndicatorStatus.Danger).Should().Be(2);
+        }
+
+        [Theory]
+        [InlineData(DangerIndicatorStatus.Safe, 1)]
+        [InlineData(DangerIndicatorStatus.Danger, 2)]
+        public void DangerIndicatorStatus_CastToInt_ShouldReturnCorrectValue(DangerIndicatorStatus status, int expectedValue)
+        {
+            // Act
+            var intValue = (int)status;
+
+            // Assert
+            intValue.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void DangerIndicatorStatus_ToString_ShouldReturnEnumName()
+        {
+            // Act & Assert
+            DangerIndicatorStatus.Safe.ToString().Should().Be("Safe");
+            DangerIndicatorStatus.Danger.ToString().Should().Be("Danger");
+        }
+    }
+
+    public class DangerIndicatorTypeEnumTests
+    {
+        [Fact]
+        public void DangerIndicatorType_ShouldHaveCorrectValues()
+        {
+            // Assert
+            ((int)DangerIndicatorType.General).Should().Be(1);
+            ((int)DangerIndicatorType.Cards).Should().Be(2);
+            ((int)DangerIndicatorType.Corners).Should().Be(3);
+        }
+
+        [Theory]
+        [InlineData(DangerIndicatorType.General, 1)]
+        [InlineData(DangerIndicatorType.Cards, 2)]
+        [InlineData(DangerIndicatorType.Corners, 3)]
+        public void DangerIndicatorType_CastToInt_ShouldReturnCorrectValue(DangerIndicatorType type, int expectedValue)
+        {
+            // Act
+            var intValue = (int)type;
+
+            // Assert
+            intValue.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void DangerIndicatorType_ToString_ShouldReturnEnumName()
+        {
+            // Act & Assert
+            DangerIndicatorType.General.ToString().Should().Be("General");
+            DangerIndicatorType.Cards.ToString().Should().Be("Cards");
+            DangerIndicatorType.Corners.ToString().Should().Be("Corners");
+        }
+    }
+
+    public class EnumGeneralTests
+    {
+        [Fact]
+        public void SomeEnums_ShouldHaveNotSetAsZero()
+        {
+            // Assert - Common pattern in the codebase for some enums
+            ((int)FixtureStatus.NotSet).Should().Be(0);
+            ((int)BetStatus.NotSet).Should().Be(0);
+        }
+
+        [Fact]
+        public void SubscriptionState_ShouldHaveAllAsZero()
+        {
+            // Assert - SubscriptionState uses All as the default/zero value
+            ((int)SubscriptionState.All).Should().Be(0);
+        }
+
+        [Fact]
+        public void AllEnums_ShouldBeValueTypes()
+        {
+            // Assert
+            typeof(FixtureStatus).IsValueType.Should().BeTrue();
+            typeof(BetStatus).IsValueType.Should().BeTrue();
+            typeof(SubscriptionState).IsValueType.Should().BeTrue();
+            typeof(DangerIndicatorStatus).IsValueType.Should().BeTrue();
+            typeof(DangerIndicatorType).IsValueType.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AllEnums_ShouldBeEnumType()
+        {
+            // Assert
+            typeof(FixtureStatus).IsEnum.Should().BeTrue();
+            typeof(BetStatus).IsEnum.Should().BeTrue();
+            typeof(SubscriptionState).IsEnum.Should().BeTrue();
+            typeof(DangerIndicatorStatus).IsEnum.Should().BeTrue();
+            typeof(DangerIndicatorType).IsEnum.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AllEnums_ShouldHaveCorrectNamespace()
+        {
+            // Assert
+            typeof(FixtureStatus).Namespace.Should().Be("Trade360SDK.Common.Entities.Enums");
+            typeof(BetStatus).Namespace.Should().Be("Trade360SDK.Common.Entities.Enums");
+            typeof(SubscriptionState).Namespace.Should().Be("Trade360SDK.Common.Entities.Enums");
+            typeof(DangerIndicatorStatus).Namespace.Should().Be("Trade360SDK.Common.Entities.Enums");
+            typeof(DangerIndicatorType).Namespace.Should().Be("Trade360SDK.Common.Entities.Enums");
+        }
+    }
+} 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Fixtures/FixtureTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Fixtures/FixtureTests.cs
@@ -1,64 +1,348 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
 using Trade360SDK.Common.Entities.Fixtures;
 using Trade360SDK.Common.Entities.Enums;
 using Trade360SDK.Common.Entities.Shared;
-using Xunit;
 
-namespace Trade360SDK.Common.Tests
+namespace Trade360SDK.Common.Entities.Tests.Entities.Fixtures
 {
     public class FixtureTests
     {
         [Fact]
-        public void Properties_ShouldGetAndSetValues()
+        public void Fixture_DefaultConstructor_ShouldCreateInstanceWithNullProperties()
         {
-            var sport = new Sport();
-            var location = new Location();
-            var league = new League();
-            var startDate = DateTime.UtcNow;
-            var lastUpdate = DateTime.UtcNow.AddMinutes(-1);
-            var participants = new List<Participant> { new Participant() };
-            var extraData = new List<NameValuePair> { new NameValuePair() };
-            var subscription = new Subscription();
-            var fixture = new Fixture
-            {
-                Sport = sport,
-                Location = location,
-                League = league,
-                StartDate = startDate,
-                LastUpdate = lastUpdate,
-                Status = FixtureStatus.Finished,
-                Participants = participants,
-                FixtureExtraData = extraData,
-                ExternalFixtureId = "EXT123",
-                Subscription = subscription
-            };
-            Assert.Equal(sport, fixture.Sport);
-            Assert.Equal(location, fixture.Location);
-            Assert.Equal(league, fixture.League);
-            Assert.Equal(startDate, fixture.StartDate);
-            Assert.Equal(lastUpdate, fixture.LastUpdate);
-            Assert.Equal(FixtureStatus.Finished, fixture.Status);
-            Assert.Equal(participants, fixture.Participants);
-            Assert.Equal(extraData, fixture.FixtureExtraData);
-            Assert.Equal("EXT123", fixture.ExternalFixtureId);
-            Assert.Equal(subscription, fixture.Subscription);
+            // Act
+            var fixture = new Fixture();
+
+            // Assert
+            fixture.Should().NotBeNull();
+            fixture.Sport.Should().BeNull();
+            fixture.Location.Should().BeNull();
+            fixture.League.Should().BeNull();
+            fixture.StartDate.Should().BeNull();
+            fixture.LastUpdate.Should().Be(default(DateTime));
+            fixture.Status.Should().Be(default(FixtureStatus));
+            fixture.Participants.Should().BeNull();
+            fixture.FixtureExtraData.Should().BeNull();
+            fixture.ExternalFixtureId.Should().BeNull();
+            fixture.Subscription.Should().BeNull();
         }
 
         [Fact]
-        public void Properties_ShouldAllowNullsAndDefaults()
+        public void Fixture_SetSport_ShouldSetValue()
         {
+            // Arrange
             var fixture = new Fixture();
-            Assert.Null(fixture.Sport);
-            Assert.Null(fixture.Location);
-            Assert.Null(fixture.League);
-            Assert.Null(fixture.StartDate);
-            Assert.Equal(default, fixture.LastUpdate);
-            Assert.Equal(FixtureStatus.NotSet, fixture.Status);
-            Assert.Null(fixture.Participants);
-            Assert.Null(fixture.FixtureExtraData);
-            Assert.Null(fixture.ExternalFixtureId);
-            Assert.Null(fixture.Subscription);
+            var sport = new Sport { Id = 1, Name = "Football" };
+
+            // Act
+            fixture.Sport = sport;
+
+            // Assert
+            fixture.Sport.Should().Be(sport);
+            fixture.Sport.Id.Should().Be(1);
+            fixture.Sport.Name.Should().Be("Football");
+        }
+
+        [Fact]
+        public void Fixture_SetLocation_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var location = new Location { Id = 1, Name = "England" };
+
+            // Act
+            fixture.Location = location;
+
+            // Assert
+            fixture.Location.Should().Be(location);
+            fixture.Location.Id.Should().Be(1);
+            fixture.Location.Name.Should().Be("England");
+        }
+
+        [Fact]
+        public void Fixture_SetLeague_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var league = new League { Id = 1, Name = "Premier League" };
+
+            // Act
+            fixture.League = league;
+
+            // Assert
+            fixture.League.Should().Be(league);
+            fixture.League.Id.Should().Be(1);
+            fixture.League.Name.Should().Be("Premier League");
+        }
+
+        [Fact]
+        public void Fixture_SetStartDate_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var startDate = new DateTime(2023, 12, 1, 15, 30, 0, DateTimeKind.Utc);
+
+            // Act
+            fixture.StartDate = startDate;
+
+            // Assert
+            fixture.StartDate.Should().Be(startDate);
+        }
+
+        [Fact]
+        public void Fixture_SetLastUpdate_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var lastUpdate = new DateTime(2023, 12, 1, 10, 0, 0, DateTimeKind.Utc);
+
+            // Act
+            fixture.LastUpdate = lastUpdate;
+
+            // Assert
+            fixture.LastUpdate.Should().Be(lastUpdate);
+        }
+
+        [Fact]
+        public void Fixture_SetStatus_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var status = FixtureStatus.InProgress;
+
+            // Act
+            fixture.Status = status;
+
+            // Assert
+            fixture.Status.Should().Be(status);
+        }
+
+        [Fact]
+        public void Fixture_SetParticipants_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var participants = new List<Participant>
+            {
+                new Participant { Id = 1, Name = "Team A" },
+                new Participant { Id = 2, Name = "Team B" }
+            };
+
+            // Act
+            fixture.Participants = participants;
+
+            // Assert
+            fixture.Participants.Should().BeEquivalentTo(participants);
+            fixture.Participants.Should().HaveCount(2);
+            fixture.Participants.First().Name.Should().Be("Team A");
+            fixture.Participants.Last().Name.Should().Be("Team B");
+        }
+
+        [Fact]
+        public void Fixture_SetFixtureExtraData_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var extraData = new List<NameValuePair>
+            {
+                new NameValuePair { Name = "Weather", Value = "Sunny" },
+                new NameValuePair { Name = "Temperature", Value = "20°C" }
+            };
+
+            // Act
+            fixture.FixtureExtraData = extraData;
+
+            // Assert
+            fixture.FixtureExtraData.Should().BeEquivalentTo(extraData);
+            fixture.FixtureExtraData.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Fixture_SetExternalFixtureId_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var externalId = "EXT-12345";
+
+            // Act
+            fixture.ExternalFixtureId = externalId;
+
+            // Assert
+            fixture.ExternalFixtureId.Should().Be(externalId);
+        }
+
+        [Fact]
+        public void Fixture_SetSubscription_ShouldSetValue()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var subscription = new Subscription();
+
+            // Act
+            fixture.Subscription = subscription;
+
+            // Assert
+            fixture.Subscription.Should().Be(subscription);
+        }
+
+        [Fact]
+        public void Fixture_SetAllProperties_ShouldSetAllValues()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var sport = new Sport { Id = 1, Name = "Football" };
+            var location = new Location { Id = 1, Name = "England" };
+            var league = new League { Id = 1, Name = "Premier League" };
+            var startDate = new DateTime(2023, 12, 1, 15, 30, 0, DateTimeKind.Utc);
+            var lastUpdate = new DateTime(2023, 12, 1, 10, 0, 0, DateTimeKind.Utc);
+            var status = FixtureStatus.InProgress;
+            var participants = new List<Participant> { new Participant { Id = 1, Name = "Team A" } };
+            var extraData = new List<NameValuePair> { new NameValuePair { Name = "Weather", Value = "Sunny" } };
+            var externalId = "EXT-12345";
+            var subscription = new Subscription();
+
+            // Act
+            fixture.Sport = sport;
+            fixture.Location = location;
+            fixture.League = league;
+            fixture.StartDate = startDate;
+            fixture.LastUpdate = lastUpdate;
+            fixture.Status = status;
+            fixture.Participants = participants;
+            fixture.FixtureExtraData = extraData;
+            fixture.ExternalFixtureId = externalId;
+            fixture.Subscription = subscription;
+
+            // Assert
+            fixture.Sport.Should().Be(sport);
+            fixture.Location.Should().Be(location);
+            fixture.League.Should().Be(league);
+            fixture.StartDate.Should().Be(startDate);
+            fixture.LastUpdate.Should().Be(lastUpdate);
+            fixture.Status.Should().Be(status);
+            fixture.Participants.Should().BeEquivalentTo(participants);
+            fixture.FixtureExtraData.Should().BeEquivalentTo(extraData);
+            fixture.ExternalFixtureId.Should().Be(externalId);
+            fixture.Subscription.Should().Be(subscription);
+        }
+
+        [Fact]
+        public void Fixture_SetEmptyCollections_ShouldSetValues()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var emptyParticipants = new List<Participant>();
+            var emptyExtraData = new List<NameValuePair>();
+
+            // Act
+            fixture.Participants = emptyParticipants;
+            fixture.FixtureExtraData = emptyExtraData;
+
+            // Assert
+            fixture.Participants.Should().BeEmpty();
+            fixture.FixtureExtraData.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Fixture_SetNullValues_ShouldSetNulls()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            // Act
+            fixture.Sport = null;
+            fixture.Location = null;
+            fixture.League = null;
+            fixture.StartDate = null;
+            fixture.Participants = null;
+            fixture.FixtureExtraData = null;
+            fixture.ExternalFixtureId = null;
+            fixture.Subscription = null;
+
+            // Assert
+            fixture.Sport.Should().BeNull();
+            fixture.Location.Should().BeNull();
+            fixture.League.Should().BeNull();
+            fixture.StartDate.Should().BeNull();
+            fixture.Participants.Should().BeNull();
+            fixture.FixtureExtraData.Should().BeNull();
+            fixture.ExternalFixtureId.Should().BeNull();
+            fixture.Subscription.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData(FixtureStatus.NotSet)]
+        [InlineData(FixtureStatus.NSY)]
+        [InlineData(FixtureStatus.InProgress)]
+        [InlineData(FixtureStatus.Finished)]
+        [InlineData(FixtureStatus.Cancelled)]
+        [InlineData(FixtureStatus.Postponed)]
+        public void Fixture_SetVariousStatuses_ShouldSetValue(FixtureStatus status)
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            // Act
+            fixture.Status = status;
+
+            // Assert
+            fixture.Status.Should().Be(status);
+        }
+
+        [Fact]
+        public void Fixture_SetDateTimeMinMax_ShouldSetValues()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            // Act
+            fixture.StartDate = DateTime.MinValue;
+            fixture.LastUpdate = DateTime.MaxValue;
+
+            // Assert
+            fixture.StartDate.Should().Be(DateTime.MinValue);
+            fixture.LastUpdate.Should().Be(DateTime.MaxValue);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("EXT-12345")]
+        [InlineData("very-long-external-fixture-id-with-many-characters")]
+        public void Fixture_SetVariousExternalIds_ShouldSetValue(string externalId)
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            // Act
+            fixture.ExternalFixtureId = externalId;
+
+            // Assert
+            fixture.ExternalFixtureId.Should().Be(externalId);
+        }
+
+        [Fact]
+        public void Fixture_PropertySettersGetters_ShouldWorkCorrectly()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            // Act & Assert - Test that we can set and get each property multiple times
+            fixture.ExternalFixtureId = "test1";
+            fixture.ExternalFixtureId.Should().Be("test1");
+            fixture.ExternalFixtureId = "test2";
+            fixture.ExternalFixtureId.Should().Be("test2");
+
+            var status1 = FixtureStatus.NotSet;
+            var status2 = FixtureStatus.InProgress;
+            fixture.Status = status1;
+            fixture.Status.Should().Be(status1);
+            fixture.Status = status2;
+            fixture.Status.Should().Be(status2);
         }
     }
 } 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Shared/NameValuePairComprehensiveTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Shared/NameValuePairComprehensiveTests.cs
@@ -1,0 +1,283 @@
+using System;
+using FluentAssertions;
+using Xunit;
+using Trade360SDK.Common.Entities.Shared;
+
+namespace Trade360SDK.Common.Entities.Tests.Entities.Shared
+{
+    public class NameValuePairComprehensiveTests
+    {
+        [Fact]
+        public void NameValuePair_DefaultConstructor_ShouldCreateInstanceWithNullProperties()
+        {
+            // Act
+            var pair = new NameValuePair();
+
+            // Assert
+            pair.Should().NotBeNull();
+            pair.Name.Should().BeNull();
+            pair.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public void NameValuePair_SetName_ShouldSetValue()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+            var name = "TestName";
+
+            // Act
+            pair.Name = name;
+
+            // Assert
+            pair.Name.Should().Be(name);
+        }
+
+        [Fact]
+        public void NameValuePair_SetValue_ShouldSetValue()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+            var value = "TestValue";
+
+            // Act
+            pair.Value = value;
+
+            // Assert
+            pair.Value.Should().Be(value);
+        }
+
+        [Fact]
+        public void NameValuePair_SetBothProperties_ShouldSetBothValues()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+            var name = "Configuration";
+            var value = "Production";
+
+            // Act
+            pair.Name = name;
+            pair.Value = value;
+
+            // Assert
+            pair.Name.Should().Be(name);
+            pair.Value.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("   ", "   ")]
+        [InlineData("Name", "Value")]
+        [InlineData("VeryLongNameWithSpecialCharacters!@#$%^&*()", "VeryLongValueWithSpecialCharacters!@#$%^&*()")]
+        [InlineData("123", "456")]
+        [InlineData("true", "false")]
+        public void NameValuePair_SetVariousValues_ShouldSetValues(string name, string value)
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = name;
+            pair.Value = value;
+
+            // Assert
+            pair.Name.Should().Be(name);
+            pair.Value.Should().Be(value);
+        }
+
+        [Fact]
+        public void NameValuePair_SetNullValues_ShouldSetNulls()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = null;
+            pair.Value = null;
+
+            // Assert
+            pair.Name.Should().BeNull();
+            pair.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public void NameValuePair_PropertySettersGetters_ShouldWorkCorrectly()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act & Assert - Test that we can set and get each property multiple times
+            pair.Name = "Name1";
+            pair.Name.Should().Be("Name1");
+            pair.Name = "Name2";
+            pair.Name.Should().Be("Name2");
+            pair.Name = null;
+            pair.Name.Should().BeNull();
+
+            pair.Value = "Value1";
+            pair.Value.Should().Be("Value1");
+            pair.Value = "Value2";
+            pair.Value.Should().Be("Value2");
+            pair.Value = null;
+            pair.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public void NameValuePair_WithConfigurationData_ShouldStoreCorrectly()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = "DatabaseConnectionString";
+            pair.Value = "Server=localhost;Database=Test;Trusted_Connection=true;";
+
+            // Assert
+            pair.Name.Should().Be("DatabaseConnectionString");
+            pair.Value.Should().Be("Server=localhost;Database=Test;Trusted_Connection=true;");
+        }
+
+        [Fact]
+        public void NameValuePair_WithJsonLikeData_ShouldStoreCorrectly()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = "JsonConfig";
+            pair.Value = "{\"key\": \"value\", \"number\": 42}";
+
+            // Assert
+            pair.Name.Should().Be("JsonConfig");
+            pair.Value.Should().Be("{\"key\": \"value\", \"number\": 42}");
+        }
+
+        [Fact]
+        public void NameValuePair_WithXmlLikeData_ShouldStoreCorrectly()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = "XmlConfig";
+            pair.Value = "<config><setting>value</setting></config>";
+
+            // Assert
+            pair.Name.Should().Be("XmlConfig");
+            pair.Value.Should().Be("<config><setting>value</setting></config>");
+        }
+
+        [Fact]
+        public void NameValuePair_WithUnicodeCharacters_ShouldStoreCorrectly()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = "Unicode测试";
+            pair.Value = "Value with émojis 🚀🎉";
+
+            // Assert
+            pair.Name.Should().Be("Unicode测试");
+            pair.Value.Should().Be("Value with émojis 🚀🎉");
+        }
+
+        [Fact]
+        public void NameValuePair_WithNewlineCharacters_ShouldStoreCorrectly()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = "MultiLine\nName";
+            pair.Value = "Line1\nLine2\rLine3\r\nLine4";
+
+            // Assert
+            pair.Name.Should().Be("MultiLine\nName");
+            pair.Value.Should().Be("Line1\nLine2\rLine3\r\nLine4");
+        }
+
+        [Fact]
+        public void NameValuePair_WithTabCharacters_ShouldStoreCorrectly()
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = "Name\twith\ttabs";
+            pair.Value = "Value\twith\ttabs";
+
+            // Assert
+            pair.Name.Should().Be("Name\twith\ttabs");
+            pair.Value.Should().Be("Value\twith\ttabs");
+        }
+
+        [Theory]
+        [InlineData("Temperature", "25.5")]
+        [InlineData("Humidity", "60%")]
+        [InlineData("Status", "Active")]
+        [InlineData("LastUpdate", "2023-12-01T10:30:00Z")]
+        [InlineData("Count", "1000")]
+        public void NameValuePair_WithCommonConfigurationPairs_ShouldStoreCorrectly(string name, string value)
+        {
+            // Arrange
+            var pair = new NameValuePair();
+
+            // Act
+            pair.Name = name;
+            pair.Value = value;
+
+            // Assert
+            pair.Name.Should().Be(name);
+            pair.Value.Should().Be(value);
+        }
+
+        [Fact]
+        public void NameValuePair_ToString_ShouldReturnStringRepresentation()
+        {
+            // Arrange
+            var pair = new NameValuePair
+            {
+                Name = "TestName",
+                Value = "TestValue"
+            };
+
+            // Act
+            var result = pair.ToString();
+
+            // Assert
+            result.Should().NotBeNullOrEmpty();
+            // ToString should return some representation of the object
+            result.Should().Contain("NameValuePair");
+        }
+
+        [Fact]
+        public void NameValuePair_GetHashCode_ShouldReturnConsistentValue()
+        {
+            // Arrange
+            var pair = new NameValuePair
+            {
+                Name = "TestName",
+                Value = "TestValue"
+            };
+
+            // Act
+            var hashCode1 = pair.GetHashCode();
+            var hashCode2 = pair.GetHashCode();
+
+            // Assert
+            hashCode1.Should().Be(hashCode2);
+        }
+
+        [Fact]
+        public void NameValuePair_Type_ShouldBeCorrect()
+        {
+            // Arrange & Act
+            var pair = new NameValuePair();
+
+            // Assert
+            pair.GetType().Should().Be(typeof(NameValuePair));
+            pair.GetType().Name.Should().Be("NameValuePair");
+        }
+    }
+} 

--- a/test/Trade360SDK.Common.Entities.Tests/Helpers/Trade360AttributeHelperTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Helpers/Trade360AttributeHelperTests.cs
@@ -4,8 +4,9 @@ using System.Reflection;
 using Trade360SDK.Common.Attributes;
 using Trade360SDK.Common.Helpers;
 using Xunit;
+using FluentAssertions;
 
-namespace Trade360SDK.Common.Tests
+namespace Trade360SDK.Common.Entities.Tests.Helpers
 {
     public class Trade360AttributeHelperTests
     {
@@ -52,6 +53,161 @@ namespace Trade360SDK.Common.Tests
             // Filter to a type name that doesn't exist
             var filtered = typesWithAttribute.Where(t => t.Name == "DefinitelyNotARealType").ToList();
             Assert.Empty(filtered);
+        }
+
+        [Fact]
+        public void GetAttributes_ShouldReturnListOfTypes()
+        {
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<System.Collections.Generic.List<Type>>();
+        }
+
+        [Fact]
+        public void GetAttributes_ShouldReturnConsistentResults()
+        {
+            // Act
+            var result1 = Trade360AttributeHelper.GetAttributes();
+            var result2 = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result1.Should().NotBeNull();
+            result2.Should().NotBeNull();
+            result1.Count.Should().Be(result2.Count);
+            
+            // The results should be consistent across multiple calls
+            if (result1.Any())
+            {
+                result1.Should().BeEquivalentTo(result2);
+            }
+        }
+
+        [Fact]
+        public void GetAttributes_ShouldReturnTypesFromExecutingAssembly()
+        {
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result.Should().NotBeNull();
+            
+            // All returned types should be from the executing assembly
+            foreach (var type in result)
+            {
+                type.Should().NotBeNull();
+                type.Assembly.Should().NotBeNull();
+            }
+        }
+
+        [Fact]
+        public void GetAttributes_MultipleCalls_ShouldNotThrow()
+        {
+            // Act & Assert
+            for (int i = 0; i < 5; i++)
+            {
+                var act = () => Trade360AttributeHelper.GetAttributes();
+                act.Should().NotThrow();
+            }
+        }
+
+        [Fact]
+        public void GetAttributes_ShouldReturnEmptyOrPopulatedList()
+        {
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result.Should().NotBeNull();
+            // The result can be empty if no types have the Trade360EntityAttribute
+            // or it can contain types that do have the attribute
+            result.Count.Should().BeGreaterThanOrEqualTo(0);
+        }
+
+        [Fact]
+        public void GetAttributes_ResultTypes_ShouldBeValidTypes()
+        {
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result.Should().NotBeNull();
+            
+            foreach (var type in result)
+            {
+                type.Should().NotBeNull();
+                type.Name.Should().NotBeNullOrEmpty();
+                type.FullName.Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [Fact]
+        public void GetAttributes_ShouldFilterTypesWithTrade360EntityAttribute()
+        {
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result.Should().NotBeNull();
+            
+            // Each type in the result should have the Trade360EntityAttribute
+            foreach (var type in result)
+            {
+                var hasAttribute = type.GetCustomAttributes(typeof(Trade360SDK.Common.Attributes.Trade360EntityAttribute), false).Any();
+                hasAttribute.Should().BeTrue($"Type {type.Name} should have Trade360EntityAttribute");
+            }
+        }
+
+        [Fact]
+        public void GetAttributes_Performance_ShouldCompleteQuickly()
+        {
+            // Arrange
+            var startTime = DateTime.UtcNow;
+
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            var endTime = DateTime.UtcNow;
+            var duration = endTime - startTime;
+            
+            result.Should().NotBeNull();
+            duration.TotalSeconds.Should().BeLessThan(5, "Method should complete within 5 seconds");
+        }
+
+        [Fact]
+        public void GetAttributes_ShouldNotReturnDuplicates()
+        {
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result.Should().NotBeNull();
+            
+            if (result.Any())
+            {
+                var distinctTypes = result.Distinct().ToList();
+                result.Count.Should().Be(distinctTypes.Count, "Result should not contain duplicate types");
+            }
+        }
+
+        [Fact]
+        public void GetAttributes_ShouldReturnConcreteTypes()
+        {
+            // Act
+            var result = Trade360AttributeHelper.GetAttributes();
+
+            // Assert
+            result.Should().NotBeNull();
+            
+            foreach (var type in result)
+            {
+                type.Should().NotBeNull();
+                // Types returned should be actual types, not null or invalid
+                type.IsClass.Should().BeTrue($"Type {type.Name} should be a class");
+            }
         }
     }
 } 

--- a/test/Trade360SDK.Common.Entities.Tests/Models/MessageHeaderTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Models/MessageHeaderTests.cs
@@ -1,43 +1,340 @@
 using System;
-using Trade360SDK.Common.Models;
+using FluentAssertions;
 using Xunit;
+using Trade360SDK.Common.Models;
 
-namespace Trade360SDK.Common.Tests
+namespace Trade360SDK.Common.Entities.Tests.Models
 {
     public class MessageHeaderTests
     {
         [Fact]
-        public void Properties_ShouldGetAndSetValues()
+        public void MessageHeader_DefaultConstructor_ShouldCreateInstanceWithNullProperties()
         {
-            var header = new MessageHeader
-            {
-                CreationDate = "2024-01-01T00:00:00Z",
-                Type = 1,
-                MsgSeq = 42,
-                MsgGuid = "guid-123",
-                ServerTimestamp = 1234567890,
-                MessageBrokerTimestamp = DateTime.UtcNow,
-                MessageTimestamp = DateTime.UtcNow.AddMinutes(-1)
-            };
+            // Act
+            var header = new MessageHeader();
 
-            Assert.Equal("2024-01-01T00:00:00Z", header.CreationDate);
-            Assert.Equal(1, header.Type);
-            Assert.Equal(42, header.MsgSeq);
-            Assert.Equal("guid-123", header.MsgGuid);
-            Assert.Equal(1234567890, header.ServerTimestamp);
-            Assert.NotNull(header.MessageBrokerTimestamp);
-            Assert.NotNull(header.MessageTimestamp);
+            // Assert
+            header.Should().NotBeNull();
+            header.CreationDate.Should().BeNull();
+            header.Type.Should().Be(0);
+            header.MsgSeq.Should().BeNull();
+            header.MsgGuid.Should().BeNull();
+            header.ServerTimestamp.Should().BeNull();
+            header.MessageBrokerTimestamp.Should().BeNull();
+            header.MessageTimestamp.Should().BeNull();
         }
 
         [Fact]
-        public void Properties_ShouldAllowNulls()
+        public void MessageHeader_SetCreationDate_ShouldSetValue()
         {
+            // Arrange
             var header = new MessageHeader();
-            Assert.Null(header.CreationDate);
-            Assert.Null(header.MsgGuid);
-            Assert.Null(header.ServerTimestamp);
-            Assert.Null(header.MessageBrokerTimestamp);
-            Assert.Null(header.MessageTimestamp);
+            var creationDate = "2023-12-01T10:30:00Z";
+
+            // Act
+            header.CreationDate = creationDate;
+
+            // Assert
+            header.CreationDate.Should().Be(creationDate);
+        }
+
+        [Fact]
+        public void MessageHeader_SetType_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var type = 42;
+
+            // Act
+            header.Type = type;
+
+            // Assert
+            header.Type.Should().Be(type);
+        }
+
+        [Fact]
+        public void MessageHeader_SetMsgSeq_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var msgSeq = 123;
+
+            // Act
+            header.MsgSeq = msgSeq;
+
+            // Assert
+            header.MsgSeq.Should().Be(msgSeq);
+        }
+
+        [Fact]
+        public void MessageHeader_SetMsgGuid_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var msgGuid = "550e8400-e29b-41d4-a716-446655440000";
+
+            // Act
+            header.MsgGuid = msgGuid;
+
+            // Assert
+            header.MsgGuid.Should().Be(msgGuid);
+        }
+
+        [Fact]
+        public void MessageHeader_SetServerTimestamp_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var timestamp = 1638360600000L; // Unix timestamp
+
+            // Act
+            header.ServerTimestamp = timestamp;
+
+            // Assert
+            header.ServerTimestamp.Should().Be(timestamp);
+        }
+
+        [Fact]
+        public void MessageHeader_SetMessageBrokerTimestamp_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var timestamp = new DateTime(2023, 12, 1, 10, 30, 0, DateTimeKind.Utc);
+
+            // Act
+            header.MessageBrokerTimestamp = timestamp;
+
+            // Assert
+            header.MessageBrokerTimestamp.Should().Be(timestamp);
+        }
+
+        [Fact]
+        public void MessageHeader_SetMessageTimestamp_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var timestamp = new DateTime(2023, 12, 1, 10, 30, 0, DateTimeKind.Utc);
+
+            // Act
+            header.MessageTimestamp = timestamp;
+
+            // Assert
+            header.MessageTimestamp.Should().Be(timestamp);
+        }
+
+        [Fact]
+        public void MessageHeader_SetAllProperties_ShouldSetAllValues()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var creationDate = "2023-12-01T10:30:00Z";
+            var type = 42;
+            var msgSeq = 123;
+            var msgGuid = "550e8400-e29b-41d4-a716-446655440000";
+            var serverTimestamp = 1638360600000L;
+            var messageBrokerTimestamp = new DateTime(2023, 12, 1, 10, 30, 0, DateTimeKind.Utc);
+            var messageTimestamp = new DateTime(2023, 12, 1, 10, 35, 0, DateTimeKind.Utc);
+
+            // Act
+            header.CreationDate = creationDate;
+            header.Type = type;
+            header.MsgSeq = msgSeq;
+            header.MsgGuid = msgGuid;
+            header.ServerTimestamp = serverTimestamp;
+            header.MessageBrokerTimestamp = messageBrokerTimestamp;
+            header.MessageTimestamp = messageTimestamp;
+
+            // Assert
+            header.CreationDate.Should().Be(creationDate);
+            header.Type.Should().Be(type);
+            header.MsgSeq.Should().Be(msgSeq);
+            header.MsgGuid.Should().Be(msgGuid);
+            header.ServerTimestamp.Should().Be(serverTimestamp);
+            header.MessageBrokerTimestamp.Should().Be(messageBrokerTimestamp);
+            header.MessageTimestamp.Should().Be(messageTimestamp);
+        }
+
+        [Fact]
+        public void MessageHeader_SetNegativeType_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var type = -1;
+
+            // Act
+            header.Type = type;
+
+            // Assert
+            header.Type.Should().Be(type);
+        }
+
+        [Fact]
+        public void MessageHeader_SetNegativeMsgSeq_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var msgSeq = -1;
+
+            // Act
+            header.MsgSeq = msgSeq;
+
+            // Assert
+            header.MsgSeq.Should().Be(msgSeq);
+        }
+
+        [Fact]
+        public void MessageHeader_SetNegativeServerTimestamp_ShouldSetValue()
+        {
+            // Arrange
+            var header = new MessageHeader();
+            var timestamp = -1L;
+
+            // Act
+            header.ServerTimestamp = timestamp;
+
+            // Assert
+            header.ServerTimestamp.Should().Be(timestamp);
+        }
+
+        [Fact]
+        public void MessageHeader_SetEmptyStringValues_ShouldSetValues()
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act
+            header.CreationDate = string.Empty;
+            header.MsgGuid = string.Empty;
+
+            // Assert
+            header.CreationDate.Should().Be(string.Empty);
+            header.MsgGuid.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void MessageHeader_SetWhitespaceStringValues_ShouldSetValues()
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act
+            header.CreationDate = "   ";
+            header.MsgGuid = "   ";
+
+            // Assert
+            header.CreationDate.Should().Be("   ");
+            header.MsgGuid.Should().Be("   ");
+        }
+
+        [Fact]
+        public void MessageHeader_SetMinMaxValues_ShouldSetValues()
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act
+            header.Type = int.MaxValue;
+            header.MsgSeq = int.MaxValue;
+            header.ServerTimestamp = long.MaxValue;
+
+            // Assert
+            header.Type.Should().Be(int.MaxValue);
+            header.MsgSeq.Should().Be(int.MaxValue);
+            header.ServerTimestamp.Should().Be(long.MaxValue);
+        }
+
+        [Fact]
+        public void MessageHeader_SetMinValues_ShouldSetValues()
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act
+            header.Type = int.MinValue;
+            header.MsgSeq = int.MinValue;
+            header.ServerTimestamp = long.MinValue;
+
+            // Assert
+            header.Type.Should().Be(int.MinValue);
+            header.MsgSeq.Should().Be(int.MinValue);
+            header.ServerTimestamp.Should().Be(long.MinValue);
+        }
+
+        [Fact]
+        public void MessageHeader_SetDateTimeMinMaxValues_ShouldSetValues()
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act
+            header.MessageBrokerTimestamp = DateTime.MinValue;
+            header.MessageTimestamp = DateTime.MaxValue;
+
+            // Assert
+            header.MessageBrokerTimestamp.Should().Be(DateTime.MinValue);
+            header.MessageTimestamp.Should().Be(DateTime.MaxValue);
+        }
+
+        [Theory]
+        [InlineData("2023-12-01T10:30:00Z")]
+        [InlineData("01/12/2023 10:30:00")]
+        [InlineData("Dec 1, 2023")]
+        [InlineData("invalid-date")]
+        public void MessageHeader_SetVariousCreationDateFormats_ShouldSetValue(string creationDate)
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act
+            header.CreationDate = creationDate;
+
+            // Assert
+            header.CreationDate.Should().Be(creationDate);
+        }
+
+        [Theory]
+        [InlineData("550e8400-e29b-41d4-a716-446655440000")]
+        [InlineData("not-a-guid")]
+        [InlineData("12345")]
+        [InlineData("")]
+        public void MessageHeader_SetVariousGuidFormats_ShouldSetValue(string msgGuid)
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act
+            header.MsgGuid = msgGuid;
+
+            // Assert
+            header.MsgGuid.Should().Be(msgGuid);
+        }
+
+        [Fact]
+        public void MessageHeader_PropertySettersGetters_ShouldWorkCorrectly()
+        {
+            // Arrange
+            var header = new MessageHeader();
+
+            // Act & Assert - Test that we can set and get each property multiple times
+            header.CreationDate = "test1";
+            header.CreationDate.Should().Be("test1");
+            header.CreationDate = "test2";
+            header.CreationDate.Should().Be("test2");
+
+            header.Type = 1;
+            header.Type.Should().Be(1);
+            header.Type = 2;
+            header.Type.Should().Be(2);
+
+            header.MsgSeq = 100;
+            header.MsgSeq.Should().Be(100);
+            header.MsgSeq = null;
+            header.MsgSeq.Should().BeNull();
+
+            header.ServerTimestamp = 1000L;
+            header.ServerTimestamp.Should().Be(1000L);
+            header.ServerTimestamp = null;
+            header.ServerTimestamp.Should().BeNull();
         }
     }
 } 


### PR DESCRIPTION
- Introduced extensive unit tests for various components including Trade360EntityAttribute, Trade360Settings, Fixture, NameValuePair, and MessageHeader.
- Enhanced test coverage by validating constructors, property setters, and various edge cases for each class.
- Utilized FluentAssertions for improved readability and clarity in assertions.
- Ensured that all properties are correctly initialized and can handle null or default values appropriately.
- Added tests for enum values and their conversions to ensure correctness across the application.