### PR TITLE
Update PackageVersion to 2.3.1 and add ProviderMarkets property to MarketLeague entity. Enhance MarketLeagueTests to validate new property functionality.

### DIFF
--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/MarketLeague.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/MarketLeague.cs
@@ -11,6 +11,8 @@ namespace Trade360SDK.Common.Entities.OutrightLeague
 
         public IEnumerable<Bet>? Bets { get; set; }
 
+        public IEnumerable<ProviderMarket>? ProviderMarkets { get; set; }
+
         public string? MainLine { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.0</PackageVersion>
+		<PackageVersion>2.3.1</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -18,6 +18,7 @@
 			- 2.0.1 Add players to livescore incident
 			- 2.1.0 Update Fixture model with new properties: FixtureName, Season. Update League and participant properties.
 			- 2.2.0 Added SportId header support for RabbitMQ message transport layer.
+			- 2.3.1 Added ProviderMarkets property to MarketLeague entity for GetOutrightLeagueMarkets API.
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/MarketLeagueTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/MarketLeagueTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Trade360SDK.Common.Entities.OutrightLeague;
 using Trade360SDK.Common.Entities.Markets;
@@ -11,16 +12,28 @@ namespace Trade360SDK.Common.Tests
         public void Properties_ShouldGetAndSetValues()
         {
             var bets = new List<Bet> { new Bet { Id = 1 } };
+            var providerMarkets = new List<ProviderMarket>
+            {
+                new ProviderMarket
+                {
+                    Id = 100,
+                    Name = "ProviderMarketName",
+                    LastUpdate = new DateTime(2025, 1, 1, 12, 0, 0),
+                    Bets = new List<ProviderBet> { new ProviderBet { Id = 1001 } }
+                }
+            };
             var league = new MarketLeague
             {
                 Id = 10,
                 Name = "LeagueName",
                 Bets = bets,
+                ProviderMarkets = providerMarkets,
                 MainLine = "2.5"
             };
             Assert.Equal(10, league.Id);
             Assert.Equal("LeagueName", league.Name);
             Assert.Equal(bets, league.Bets);
+            Assert.Equal(providerMarkets, league.ProviderMarkets);
             Assert.Equal("2.5", league.MainLine);
         }
 
@@ -30,6 +43,7 @@ namespace Trade360SDK.Common.Tests
             var league = new MarketLeague();
             Assert.Null(league.Name);
             Assert.Null(league.Bets);
+            Assert.Null(league.ProviderMarkets);
             Assert.Null(league.MainLine);
         }
     }


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>MarketLeague</code> entity by adding a <code>ProviderMarkets</code> property to support market provider data and increments the package version to 2.3.1. Enhances the domain model to allow for better tracking of provider-specific market information within the outright league context.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>itsikha@gmail.com</td><td>Tests-outright-fix-get...</td><td>July 25, 2024</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/81?tool=ast>(Baz)</a>.