### PR TITLE
fixing samples due bug- https://lsports-data.atlassian.net/browse/TR-23141

### DIFF
--- a/sdk.samples/Trade360SDK.SnapshotApi.Example/SampleService.cs
+++ b/sdk.samples/Trade360SDK.SnapshotApi.Example/SampleService.cs
@@ -113,8 +113,8 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetFixturesRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
-                Fixtures = new List<int>() { 24770989 },
+                Sports = new List<int>() { 452674 },
+                Fixtures = new List<int>()  {/* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
             };
@@ -131,7 +131,7 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetMarketRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
+                Sports = new List<int>() { 452674 },
                 Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
@@ -147,7 +147,7 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetMarketRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
+                Sports = new List<int>() { 452674 },
                 Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
@@ -163,8 +163,8 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetLivescoreRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
-                Fixtures = new List<int>() {  },
+                Sports = new List<int>() { 452674 },
+                Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
             };
@@ -180,8 +180,8 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetFixturesRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
-                Fixtures = new List<int>() { 24770989 },
+                Sports = new List<int>() { 452674 },
+                Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
             };
@@ -198,7 +198,7 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetMarketRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
+                Sports = new List<int>() { 452674 },
                 Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
@@ -214,7 +214,7 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetMarketRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
+                Sports = new List<int>() { 452674 },
                 Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
@@ -230,7 +230,7 @@ namespace Trade360SDK.SnapshotApi.Example
 
             var request = new GetLivescoreRequestDto()
             {
-                Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
+                Sports = new List<int>() { 452674 },
                 Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Leagues = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
@@ -247,7 +247,7 @@ namespace Trade360SDK.SnapshotApi.Example
             var request = new GetOutrightFixturesRequestDto()
             {
                 Sports = new List<int>() { /* List of sport IDs, e.g., 1234, 2345 */ },
-                Fixtures = new List<int>() { 24775553/* List of fixture IDs, e.g., 12345678, 23456789 */ },
+                Fixtures = new List<int>() { /* List of fixture IDs, e.g., 12345678, 23456789 */ },
                 Tournaments = new List<int>() { /* List of league IDs, e.g., 1111, 2222 */ },
                 Locations = new List<int>() { /* List of location IDs, e.g., 3333, 4444 */ }
             };


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the sample service to request data for sport <code>452674</code> across the snapshot and prematch flows so the sample requests use valid filters instead of placeholder fixture IDs.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Add InPlay and PreMatc...</td><td>November 19, 2025</td></tr>
<tr><td>noam.m@lsports.eu</td><td>Feature, TR-13845, Enh...</td><td>September 04, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/89?tool=ast>(Baz)</a>.