### PR TITLE
Update validation messages for heartbeat and recovery interval

### DIFF
--- a/src/Trade360SDK.Feed.RabbitMQ/Validators/RmqConnectionSettingsValidator.cs
+++ b/src/Trade360SDK.Feed.RabbitMQ/Validators/RmqConnectionSettingsValidator.cs
@@ -26,10 +26,10 @@ namespace Trade360SDK.Feed.RabbitMQ.Validators
                 throw new ArgumentException("Password is required.", nameof(settings.Password));
 
             if (settings.RequestedHeartbeatSeconds <= 10)
-                throw new ArgumentException("RequestedHeartbeatSeconds must be a positive integer - Larger then 9.", nameof(settings.RequestedHeartbeatSeconds));
+                throw new ArgumentException("RequestedHeartbeatSeconds must be a positive integer - Larger than 9.", nameof(settings.RequestedHeartbeatSeconds));
 
             if (settings.NetworkRecoveryInterval <= 15)
-                throw new ArgumentException("NetworkRecoveryInterval must be a positive integer - Larger then 14.", nameof(settings.NetworkRecoveryInterval));
+                throw new ArgumentException("NetworkRecoveryInterval must be a positive integer - Larger than 14.", nameof(settings.NetworkRecoveryInterval));
         }
     }
 }

--- a/src/Trade360SDK.Feed.RabbitMQ/Validators/RmqConnectionSettingsValidator.cs
+++ b/src/Trade360SDK.Feed.RabbitMQ/Validators/RmqConnectionSettingsValidator.cs
@@ -26,10 +26,10 @@ namespace Trade360SDK.Feed.RabbitMQ.Validators
                 throw new ArgumentException("Password is required.", nameof(settings.Password));
 
             if (settings.RequestedHeartbeatSeconds <= 10)
-                throw new ArgumentException("RequestedHeartbeatSeconds must be a positive integer - Larger then 10.", nameof(settings.RequestedHeartbeatSeconds));
+                throw new ArgumentException("RequestedHeartbeatSeconds must be a positive integer - Larger then 9.", nameof(settings.RequestedHeartbeatSeconds));
 
             if (settings.NetworkRecoveryInterval <= 15)
-                throw new ArgumentException("NetworkRecoveryInterval must be a positive integer.", nameof(settings.NetworkRecoveryInterval));
+                throw new ArgumentException("NetworkRecoveryInterval must be a positive integer - Larger then 14.", nameof(settings.NetworkRecoveryInterval));
         }
     }
 }


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust validation messages for the RabbitMQ connection validator to explain minimum heartbeat and recovery limits. Clarify <code>RmqConnectionSettingsValidator</code> to highlight required thresholds for heartbeat and network recovery interval in the messaging flow.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>itsikha@gmail.com</td><td>Feed api connect at st...</td><td>July 13, 2024</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/91?tool=ast>(Baz)</a>.