### PR TITLE
fix(TR-23835): make OutrightLeague EndDate nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Release Version 2.5.2]
+
+### [Trade360SDK.Common.Entities - v2.3.3]
+
+#### Fixed
+
+- Made `OutrightLeagueFixture.EndDate` nullable so RMQ payloads with `"EndDate": null` deserialize without `System.Text.Json` errors.
+
+### [Trade360SDK.SnapshotApi - v1.4.2]
+
+#### Fixed
+
+- Made `OutrightLeagueFixtureSnapshotResponse.EndDate` nullable so snapshot payloads with `"EndDate": null` deserialize without `System.Text.Json` errors.
+
+### Backward Compatibility (v2.5.2)
+
+All changes are backward compatible. `EndDate` remains optional and now accepts null values from the API.
+
+---
+
 ## [Release Version 2.5.1]
 
 ### [Trade360SDK.Common.Entities - v2.3.2]

--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueFixture.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueFixture.cs
@@ -24,7 +24,7 @@ namespace Trade360SDK.Common.Entities.OutrightLeague
 
         public IEnumerable<NameValuePair>? ExtraData { get; set; }
         
-        public DateTime EndDate { get; set; }
+        public DateTime? EndDate { get; set; }
         
         public IdNamePair? Season { get; set; }
     }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.2</PackageVersion>
+		<PackageVersion>2.3.3</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -20,6 +20,7 @@
 			- 2.2.0 Added SportId header support for RabbitMQ message transport layer.
 			- 2.3.1 Added ProviderMarkets property to MarketLeague entity for GetOutrightLeagueMarkets API.
 			- 2.3.2 Added participant shirt color objects (ShirtColor, GoalKeeperShirtColor), added StatusDescription values 46-59, and added StartDate to OutrightLeagueFixture.
+			- 2.3.3 Made OutrightLeagueFixture.EndDate nullable to support null payloads.
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/src/Trade360SDK.SnapshotApi/Entities/Responses/GetOutrightLeaguesFixturesResponse.cs
+++ b/src/Trade360SDK.SnapshotApi/Entities/Responses/GetOutrightLeaguesFixturesResponse.cs
@@ -46,7 +46,7 @@ namespace Trade360SDK.SnapshotApi.Entities.Responses
 
         public IEnumerable<NameValuePair>? ExtraData { get; set; }
         
-        public DateTime EndDate { get; set; }
+        public DateTime? EndDate { get; set; }
         
         public IdNamePair? Season { get; set; }
     }

--- a/src/Trade360SDK.SnapshotApi/Trade360SDK.SnapshotApi.csproj
+++ b/src/Trade360SDK.SnapshotApi/Trade360SDK.SnapshotApi.csproj
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
-    <PackageVersion>1.4.1</PackageVersion>
+    <PackageVersion>1.4.2</PackageVersion>
     <PackageReleaseNotes>
       - 1.1.0 Added GetOutrightLeagueEvents API method and GetOutrightLeagueEventsResponse entity to support outright league events retrieval
 	  - 1.2.0 Added endDate property to OutrightFixture entity
 	  - 1.3.0 Added venue support to OutrightFixtureSnapshotResponse with FixtureVenue property
 	  - 1.3.1 Added support of inplay outright league snapshot endpoints
       - 1.4.1 Added StartDate to OutrightLeagueFixtureSnapshotResponse.
+      - 1.4.2 Made OutrightLeagueFixtureSnapshotResponse.EndDate nullable to support null payloads.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueFixtureTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueFixtureTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using Trade360SDK.Common.Entities.OutrightLeague;
 using Trade360SDK.Common.Entities.Enums;
 using Trade360SDK.Common.Entities.Fixtures;
@@ -61,7 +62,27 @@ namespace Trade360SDK.Common.Tests
             Assert.Equal(default, fixture.LastUpdate);
             Assert.Equal(FixtureStatus.NotSet, fixture.Status);
             Assert.Null(fixture.ExtraData);
+            Assert.Null(fixture.EndDate);
             Assert.Null(fixture.Season);
+        }
+
+        [Fact]
+        public void EndDate_ShouldDeserializeNullFromJson()
+        {
+            const string json = """
+                {
+                    "EndDate": null,
+                    "StartDate": "2026-07-04T10:00:00Z",
+                    "LastUpdate": "2026-05-03T08:51:37.990863Z",
+                    "Status": 1
+                }
+                """;
+
+            var fixture = JsonSerializer.Deserialize<OutrightLeagueFixture>(json);
+
+            Assert.NotNull(fixture);
+            Assert.Null(fixture.EndDate);
+            Assert.NotNull(fixture.StartDate);
         }
 
         [Fact]

--- a/test/Trade360SDK.SnapshotApi.Tests/Entities/Responses/GetOutrightLeaguesFixturesResponseTests.cs
+++ b/test/Trade360SDK.SnapshotApi.Tests/Entities/Responses/GetOutrightLeaguesFixturesResponseTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using Trade360SDK.SnapshotApi.Entities.Responses;
 using Trade360SDK.Common.Entities.Enums;
 using Trade360SDK.Common.Entities.Fixtures;
@@ -100,6 +101,25 @@ namespace Trade360SDK.SnapshotApi.Tests.Entities.Responses
 
             Assert.Null(outrightLeague.FixtureName);
             Assert.Null(outrightLeague.Season);
+        }
+
+        [Fact]
+        public void EndDate_ShouldDeserializeNullFromJson()
+        {
+            const string json = """
+                {
+                    "EndDate": null,
+                    "StartDate": "2026-07-04T10:00:00Z",
+                    "LastUpdate": "2026-05-03T08:51:37.990863Z",
+                    "Status": 1
+                }
+                """;
+
+            var outrightLeague = JsonSerializer.Deserialize<OutrightLeagueFixtureSnapshotResponse>(json);
+
+            Assert.NotNull(outrightLeague);
+            Assert.Null(outrightLeague.EndDate);
+            Assert.NotNull(outrightLeague.StartDate);
         }
     }
 } 


### PR DESCRIPTION
# User description
## Summary
- Make `OutrightLeagueFixture.EndDate` and `OutrightLeagueFixtureSnapshotResponse.EndDate` nullable so payloads with `"EndDate": null` deserialize without `System.Text.Json` errors.
- Bump `Trade360SDK.Common.Entities` to `2.3.3` and `Trade360SDK.SnapshotApi` to `1.4.2`.
- Document release `2.5.2` in `CHANGELOG.md` and add regression tests for null `EndDate` deserialization.

## Jira
https://lsports-data.atlassian.net/browse/TR-23835

## Test plan
- [x] `dotnet test` for `OutrightLeagueFixtureTests`
- [x] `dotnet test` for `GetOutrightLeaguesFixturesResponseTests`

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Allow <code>Trade360SDK.Common.Entities</code>’s <code>OutrightLeagueFixture.EndDate</code> (which deserializes RMQ payloads) to accept null values by making it nullable. Document the v2.5.2 release for <code>Trade360SDK.Common.Entities</code> and <code>Trade360SDK.SnapshotApi</code> in <code>CHANGELOG.md</code>, highlighting the null <code>EndDate</code> compatibility fix.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/94?tool=ast&topic=Release+notes>Release notes</a>
        </td><td>Document the v2.5.2 release for <code>Trade360SDK.Common.Entities</code> and <code>Trade360SDK.SnapshotApi</code>, noting the nullable <code>EndDate</code> fix.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix(TR-23835): make Ou...</td><td>May 11, 2026</td></tr>
<tr><td>PavelTemno</td><td>add release notes</td><td>January 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/94?tool=ast&topic=EndDate+null+handling>EndDate null handling</a>
        </td><td>Allow <code>OutrightLeagueFixture.EndDate</code> to be nullable so RMQ payloads with <code>EndDate: null</code> deserialize without <code>System.Text.Json</code> errors.<details><summary>Modified files (1)</summary><ul><li>src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueFixture.cs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix(TR-23835): make Ou...</td><td>May 11, 2026</td></tr>
<tr><td>PavelTemno</td><td>set fields nullable</td><td>January 26, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/94?tool=ast>(Baz)</a>.