### PR TITLE
Add NextFixtureStartTime to OutrightLeagueMarketUpdate (type 40).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+---
+
+## [Release Version 2.5.3]
+
+### [Trade360SDK.Common.Entities - v2.3.4]
+
+#### Added
+
+- Added `NextFixtureStartTime` to `OutrightLeagueMarketCompetitionWrapper` for `OutrightLeagueMarketUpdate` (message type 40) (TR-22695).
+
+### Backward Compatibility (v2.5.3)
+
+All changes are backward compatible. The new field is optional and scoped to outright league market messages only.
+
+---
+
 ## [Release Version 2.5.2]
 
 ### [Trade360SDK.Common.Entities - v2.3.3]

--- a/src/Trade360SDK.Common.Entities/Entities/MessageTypes/OutrightLeagueMarketUpdate.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/MessageTypes/OutrightLeagueMarketUpdate.cs
@@ -1,4 +1,6 @@
-﻿using Trade360SDK.Common.Attributes;
+﻿using System;
+using System.Text.Json.Serialization;
+using Trade360SDK.Common.Attributes;
 using Trade360SDK.Common.Entities.OutrightLeague;
 
 namespace Trade360SDK.Common.Entities.MessageTypes
@@ -6,6 +8,10 @@ namespace Trade360SDK.Common.Entities.MessageTypes
     [Trade360Entity(40)]
     public class OutrightLeagueMarketUpdate : MessageUpdate
     {
-        public OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>? Competition { get; set; }
+        [JsonConverter(typeof(OutrightLeagueMarketCompetitionWrapperConverter))]
+        public OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>? Competition { get; set; }
+
+        public DateTime? GetNextFixtureStartTime() =>
+            (Competition as OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>)?.NextFixtureStartTime;
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/MessageTypes/OutrightLeagueMarketUpdate.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/MessageTypes/OutrightLeagueMarketUpdate.cs
@@ -6,6 +6,6 @@ namespace Trade360SDK.Common.Entities.MessageTypes
     [Trade360Entity(40)]
     public class OutrightLeagueMarketUpdate : MessageUpdate
     {
-        public OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>? Competition { get; set; }
+        public OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>? Competition { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapper.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapper.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace Trade360SDK.Common.Entities.OutrightLeague
+{
+    public class OutrightLeagueMarketCompetitionWrapper<TEvent> : OutrightLeagueCompetitionWrapper<TEvent>
+    {
+        public DateTime? NextFixtureStartTime { get; set; }
+    }
+}

--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapperConverter.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapperConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Trade360SDK.Common.Entities.OutrightLeague
+{
+    internal sealed class OutrightLeagueMarketCompetitionWrapperConverter
+        : JsonConverter<OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>?>
+    {
+        public override OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>? Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            return JsonSerializer.Deserialize<OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>>(
+                ref reader,
+                options);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>? value,
+            JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(
+                writer,
+                value,
+                value?.GetType() ?? typeof(OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>),
+                options);
+        }
+    }
+}

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -25,4 +25,8 @@
 		</PackageReleaseNotes>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<PackageReference Include="System.Text.Json" Version="9.0.0" />
+	</ItemGroup>
+
 </Project>

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.3</PackageVersion>
+		<PackageVersion>2.3.4</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -21,6 +21,7 @@
 			- 2.3.1 Added ProviderMarkets property to MarketLeague entity for GetOutrightLeagueMarkets API.
 			- 2.3.2 Added participant shirt color objects (ShirtColor, GoalKeeperShirtColor), added StatusDescription values 46-59, and added StartDate to OutrightLeagueFixture.
 			- 2.3.3 Made OutrightLeagueFixture.EndDate nullable to support null payloads.
+			- 2.3.4 Added NextFixtureStartTime to OutrightLeagueMarketUpdate (type 40) via OutrightLeagueMarketCompetitionWrapper.
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
@@ -68,5 +68,43 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
             market.ProviderMarkets.Should().HaveCount(1);
             market.ProviderMarkets!.First().Name.Should().Be("Bet365");
         }
+
+        [Fact]
+        public void GetNextFixtureStartTime_WhenCompetitionIsBaseWrapper_ShouldReturnNull()
+        {
+            var update = new OutrightLeagueMarketUpdate
+            {
+                Competition = new OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>
+                {
+                    Id = 67,
+                    Name = "League_67",
+                    Type = 3,
+                }
+            };
+
+            update.GetNextFixtureStartTime().Should().BeNull();
+        }
+
+        [Fact]
+        public void GetNextFixtureStartTime_WhenCompetitionIsNull_ShouldReturnNull()
+        {
+            var update = new OutrightLeagueMarketUpdate();
+
+            update.GetNextFixtureStartTime().Should().BeNull();
+        }
+
+        [Fact]
+        public void JsonSerialization_ShouldRoundTripWithNextFixtureStartTime()
+        {
+            var json = File.ReadAllText(Path.Combine("Fixtures", "outright-league-market-update-type40.json"));
+
+            var original = JsonSerializer.Deserialize<OutrightLeagueMarketUpdate>(json, FeedJsonOptions);
+            var serialized = JsonSerializer.Serialize(original, FeedJsonOptions);
+            var roundTripped = JsonSerializer.Deserialize<OutrightLeagueMarketUpdate>(serialized, FeedJsonOptions);
+
+            roundTripped.Should().NotBeNull();
+            roundTripped!.GetNextFixtureStartTime().Should().Be(DateTime.Parse("2026-05-29T14:44:55Z").ToUniversalTime());
+            roundTripped.Competition.Should().BeOfType<OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>>();
+        }
     }
-} 
+}

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using FluentAssertions;
 using Trade360SDK.Common.Entities.MessageTypes;
 using Trade360SDK.Common.Entities.OutrightLeague;
 using Xunit;
@@ -6,10 +11,16 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
 {
     public class OutrightLeagueMarketUpdateTests
     {
+        private static readonly JsonSerializerOptions FeedJsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
         [Fact]
         public void Properties_ShouldGetAndSetValues()
         {
-            var competition = new OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>();
+            var competition = new OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>();
             var update = new OutrightLeagueMarketUpdate
             {
                 Competition = competition
@@ -22,6 +33,39 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
         {
             var update = new OutrightLeagueMarketUpdate();
             Assert.Null(update.Competition);
+        }
+
+        [Fact]
+        public void JsonDeserialization_WithCompleteRealWorldPayload_ShouldCreateCorrectEntity()
+        {
+            var json = File.ReadAllText(Path.Combine("Fixtures", "outright-league-market-update-type40.json"));
+
+            var result = JsonSerializer.Deserialize<OutrightLeagueMarketUpdate>(json, FeedJsonOptions);
+
+            result.Should().NotBeNull();
+            result!.Competition.Should().NotBeNull();
+            result.Competition!.Id.Should().Be(67);
+            result.Competition.Name.Should().Be("League_67");
+            result.Competition.Type.Should().Be(3);
+            result.Competition.NextFixtureStartTime.Should().Be(DateTime.Parse("2026-05-29T14:44:55Z").ToUniversalTime());
+
+            var season = result.Competition.Competitions!.Single();
+            season.Id.Should().Be(2029);
+            season.Name.Should().Be("Season_2029");
+            season.Type.Should().Be(4);
+
+            var marketEvent = season.Events!.Single();
+            marketEvent.FixtureId.Should().Be(26721036);
+            marketEvent.Markets.Should().HaveCount(1);
+
+            var market = marketEvent.Markets!.Single();
+            market.Id.Should().Be(274);
+            market.Name.Should().Be("Outright Winner");
+            market.Bets.Should().HaveCount(2);
+            market.Bets!.First().Name.Should().Be("Not Simply Simon");
+            market.Bets.First().ParticipantId.Should().Be(51523593);
+            market.ProviderMarkets.Should().HaveCount(1);
+            market.ProviderMarkets!.First().Name.Should().Be("Bet365");
         }
     }
 } 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
@@ -44,10 +44,11 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
 
             result.Should().NotBeNull();
             result!.Competition.Should().NotBeNull();
+            result.Competition.Should().BeOfType<OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>>();
             result.Competition!.Id.Should().Be(67);
             result.Competition.Name.Should().Be("League_67");
             result.Competition.Type.Should().Be(3);
-            result.Competition.NextFixtureStartTime.Should().Be(DateTime.Parse("2026-05-29T14:44:55Z").ToUniversalTime());
+            result.GetNextFixtureStartTime().Should().Be(DateTime.Parse("2026-05-29T14:44:55Z").ToUniversalTime());
 
             var season = result.Competition.Competitions!.Single();
             season.Id.Should().Be(2029);

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapperConverterTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapperConverterTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using Trade360SDK.Common.Entities.OutrightLeague;
+using Xunit;
+
+namespace Trade360SDK.Common.Tests
+{
+    public class OutrightLeagueMarketCompetitionWrapperConverterTests
+    {
+        private static readonly JsonSerializerOptions FeedJsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        private readonly OutrightLeagueMarketCompetitionWrapperConverter _converter = new();
+
+        [Fact]
+        public void Write_WithMarketWrapper_ShouldSerializeNextFixtureStartTime()
+        {
+            var wrapper = new OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>
+            {
+                Id = 67,
+                Name = "League_67",
+                Type = 3,
+                NextFixtureStartTime = new DateTime(2026, 5, 29, 14, 44, 55, DateTimeKind.Utc),
+            };
+
+            using var document = SerializeToDocument(wrapper);
+
+            document.RootElement.GetProperty("id").GetInt32().Should().Be(67);
+            document.RootElement.GetProperty("nextFixtureStartTime").GetDateTime()
+                .Should().Be(new DateTime(2026, 5, 29, 14, 44, 55, DateTimeKind.Utc));
+        }
+
+        [Fact]
+        public void Write_WithNullValue_ShouldSerializeNull()
+        {
+            using var document = SerializeToDocument(null);
+
+            document.RootElement.ValueKind.Should().Be(JsonValueKind.Null);
+        }
+
+        [Fact]
+        public void ReadAndWrite_ShouldRoundTripMarketWrapper()
+        {
+            var options = new JsonSerializerOptions(FeedJsonOptions);
+            options.Converters.Add(new OutrightLeagueMarketCompetitionWrapperConverter());
+
+            var original = new OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>
+            {
+                Id = 67,
+                Name = "League_67",
+                Type = 3,
+                NextFixtureStartTime = new DateTime(2026, 5, 29, 14, 44, 55, DateTimeKind.Utc),
+            };
+
+            var json = JsonSerializer.Serialize(original, options);
+            var roundTripped = JsonSerializer.Deserialize<OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>>(
+                json,
+                options);
+
+            roundTripped.Should().BeOfType<OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>>();
+            var marketWrapper = (OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>)roundTripped!;
+            marketWrapper.NextFixtureStartTime.Should().Be(new DateTime(2026, 5, 29, 14, 44, 55, DateTimeKind.Utc));
+        }
+
+        private JsonDocument SerializeToDocument(OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>? value)
+        {
+            using var stream = new System.IO.MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream))
+            {
+                _converter.Write(writer, value, FeedJsonOptions);
+            }
+
+            stream.Position = 0;
+            return JsonDocument.Parse(stream);
+        }
+    }
+}

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapperTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapperTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Trade360SDK.Common.Entities.OutrightLeague;
+using Xunit;
+
+namespace Trade360SDK.Common.Tests
+{
+    public class OutrightLeagueMarketCompetitionWrapperTests
+    {
+        [Fact]
+        public void NextFixtureStartTime_ShouldGetAndSetValue()
+        {
+            var wrapper = new OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>
+            {
+                Id = 67,
+                Name = "League_67",
+                Type = 3,
+                NextFixtureStartTime = new DateTime(2026, 5, 29, 14, 44, 55, DateTimeKind.Utc),
+            };
+
+            Assert.Equal(67, wrapper.Id);
+            Assert.Equal("League_67", wrapper.Name);
+            Assert.Equal(3, wrapper.Type);
+            Assert.Equal(new DateTime(2026, 5, 29, 14, 44, 55, DateTimeKind.Utc), wrapper.NextFixtureStartTime);
+        }
+
+        [Fact]
+        public void NextFixtureStartTime_ShouldAllowNull()
+        {
+            var wrapper = new OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>();
+            Assert.Null(wrapper.NextFixtureStartTime);
+        }
+    }
+}

--- a/test/Trade360SDK.Common.Entities.Tests/Fixtures/outright-league-market-update-type40.json
+++ b/test/Trade360SDK.Common.Entities.Tests/Fixtures/outright-league-market-update-type40.json
@@ -1,0 +1,71 @@
+{
+  "Competition": {
+    "Id": 67,
+    "Name": "League_67",
+    "Type": 3,
+    "NextFixtureStartTime": "2026-05-29T14:44:55Z",
+    "Competitions": [
+      {
+        "Id": 2029,
+        "Name": "Season_2029",
+        "Type": 4,
+        "Events": [
+          {
+            "FixtureId": 26721036,
+            "Livescore": null,
+            "Markets": [
+              {
+                "Id": 274,
+                "Name": "Outright Winner",
+                "Bets": [
+                  {
+                    "Probability": -1.0,
+                    "Id": 2655634626721036,
+                    "Name": "Not Simply Simon",
+                    "Status": 1,
+                    "StartPrice": "1.5",
+                    "Price": "1.5",
+                    "ProviderBetId": "8",
+                    "LastUpdate": "2026-05-27T17:44:59.54+03:00",
+                    "SerializedLastUpdate": "2026-05-27T17:44:59.540Z",
+                    "ParticipantId": 51523593
+                  },
+                  {
+                    "Probability": -1.0,
+                    "Id": 201914637926721036,
+                    "Name": "Ranger Annie",
+                    "Status": 1,
+                    "StartPrice": "2.5",
+                    "Price": "2.5",
+                    "ProviderBetId": "8",
+                    "LastUpdate": "2026-05-27T17:44:59.54+03:00",
+                    "SerializedLastUpdate": "2026-05-27T17:44:59.540Z",
+                    "ParticipantId": 51523594
+                  }
+                ],
+                "ProviderMarkets": [
+                  {
+                    "Id": 8,
+                    "Name": "Bet365",
+                    "LastUpdate": "2026-05-27T17:44:58.254+03:00",
+                    "SerializedLastUpdate": "2026-05-27T17:44:58.254Z",
+                    "Bets": [
+                      {
+                        "Name": "Not Simply Simon",
+                        "Status": 1,
+                        "StartPrice": "1.5",
+                        "Price": "1.5",
+                        "LastUpdate": "2026-05-27T17:44:55.579+03:00",
+                        "SerializedLastUpdate": "2026-05-27T17:44:55.579Z"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/Trade360SDK.Common.Entities.Tests/Trade360SDK.Common.Entities.Tests.csproj
+++ b/test/Trade360SDK.Common.Entities.Tests/Trade360SDK.Common.Entities.Tests.csproj
@@ -25,4 +25,10 @@
     <ProjectReference Include="../../src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Fixtures\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# User description
Use OutrightLeagueMarketCompetitionWrapper so the field is scoped to outright league market messages only.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add NextFixtureStartTime tracking to outright league market messages by deriving <code>OutrightLeagueMarketCompetitionWrapper</code> from <code>OutrightLeagueCompetitionWrapper</code> and surfacing the optional timestamp on the <code>Competition</code> property of <code>OutrightLeagueMarketUpdate</code>. Include <code>OutrightLeagueMarketCompetitionWrapperConverter</code> so the new wrapper serializes correctly and scope the change to message type 40 updates.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Keep OutrightLeagueMar...</td><td>May 31, 2026</td></tr>
<tr><td>PavelTemno</td><td>add release notes</td><td>January 26, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/95?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>