### PR TITLE
feat: add MMA status descriptions (IDs 60-72) — DIN-23830

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`RabbitMqFeedException`** messaging for **`AuthenticationFailureException`** (credentials / virtual host).
 - When **`SslEnabled`** is true but **`Port`** is the plain AMQP port (**5672**), or **`SslEnabled`** is false but **`Port`** is the usual TLS port (**5671**), and the failure includes **`BrokerUnreachableException`**, a targeted **`RabbitMqFeedException`** explains the TLS vs plain port mismatch.
 
-### Trade360SDK.Common.Entities
+### Trade360SDK.Common.Entities — v2.3.5
 
 #### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`RabbitMqFeedException`** messaging for **`AuthenticationFailureException`** (credentials / virtual host).
 - When **`SslEnabled`** is true but **`Port`** is the plain AMQP port (**5672**), or **`SslEnabled`** is false but **`Port`** is the usual TLS port (**5671**), and the failure includes **`BrokerUnreachableException`**, a targeted **`RabbitMqFeedException`** explains the TLS vs plain port mismatch.
 
+### Trade360SDK.Common.Entities
+
+#### Added
+
+- **`StatusDescription`**: 13 new MMA/fight-outcome and positional enum values — `Fighter1Disqualification` (60), `Fighter2Disqualification` (61), `Fighter1MajorityDecision` (62), `Fighter2MajorityDecision` (63), `Fighter1UnanimousDecision` (64), `Fighter2UnanimousDecision` (65), `Fighter1Submission` (66), `Fighter2Submission` (67), `Fighter1KoTko` (68), `Fighter2KoTko` (69), `NoContest` (70), `Top` (71), `Bottom` (72).
+
 ---
 
 ---

--- a/src/Trade360SDK.Common.Entities/Entities/Enums/StatusDescription.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Enums/StatusDescription.cs
@@ -1,4 +1,4 @@
-﻿namespace Trade360SDK.Common.Entities.Enums
+namespace Trade360SDK.Common.Entities.Enums
 {
     public enum StatusDescription
     {
@@ -61,6 +61,19 @@
         WaitingForPenalties = 56,
         EnteringExtraTime = 57,
         ExtraTimeBreak = 58,
-        EnteringPenaltyShootout = 59
+        EnteringPenaltyShootout = 59,
+        Fighter1Disqualification = 60,
+        Fighter2Disqualification = 61,
+        Fighter1MajorityDecision = 62,
+        Fighter2MajorityDecision = 63,
+        Fighter1UnanimousDecision = 64,
+        Fighter2UnanimousDecision = 65,
+        Fighter1Submission = 66,
+        Fighter2Submission = 67,
+        Fighter1KoTko = 68,
+        Fighter2KoTko = 69,
+        NoContest = 70,
+        Top = 71,
+        Bottom = 72
     }
 }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.4</PackageVersion>
+		<PackageVersion>2.3.5</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -22,6 +22,7 @@
 			- 2.3.2 Added participant shirt color objects (ShirtColor, GoalKeeperShirtColor), added StatusDescription values 46-59, and added StartDate to OutrightLeagueFixture.
 			- 2.3.3 Made OutrightLeagueFixture.EndDate nullable to support null payloads.
 			- 2.3.4 Added NextFixtureStartTime to OutrightLeagueMarketUpdate (type 40) via OutrightLeagueMarketCompetitionWrapper.
+			- 2.3.5 Added 13 MMA/fight-outcome and positional StatusDescription enum values (IDs 60-72).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Enums/StatusDescriptionTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Enums/StatusDescriptionTests.cs
@@ -68,6 +68,19 @@ namespace Trade360SDK.Common.Tests.Entities.Enums
             Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.EnteringExtraTime));
             Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.ExtraTimeBreak));
             Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.EnteringPenaltyShootout));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1Disqualification));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2Disqualification));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1MajorityDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2MajorityDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1UnanimousDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2UnanimousDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1Submission));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2Submission));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1KoTko));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2KoTko));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.NoContest));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Top));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Bottom));
         }
     }
-} 
+}


### PR DESCRIPTION
# User description
## Summary
Adds 13 new `StatusDescription` enum values for MMA/fight-outcome and positional statuses, aligned with the upstream `LSports.Legacy.Common.Entities` enum extension (DIN-23830).

## Changes
- `src/Trade360SDK.Common.Entities/Entities/Enums/StatusDescription.cs` — appended IDs 60-72
- `test/Trade360SDK.Common.Entities.Tests/Entities/Enums/StatusDescriptionTests.cs` — added assertions for all 13 new values

## New values

| Id | Name | Description |
| --- | --- | --- |
| 60 | Fighter1Disqualification | 1 - Disqualification |
| 61 | Fighter2Disqualification | 2 - Disqualification |
| 62 | Fighter1MajorityDecision | 1 - Majority Decision |
| 63 | Fighter2MajorityDecision | 2 - Majority Decision |
| 64 | Fighter1UnanimousDecision | 1 - Unanimous Decision |
| 65 | Fighter2UnanimousDecision | 2 - Unanimous Decision |
| 66 | Fighter1Submission | 1 - Submission |
| 67 | Fighter2Submission | 2 - Submission |
| 68 | Fighter1KoTko | 1 - KO/TKO |
| 69 | Fighter2KoTko | 2 - KO/TKO |
| 70 | NoContest | No contest |
| 71 | Top | Top |
| 72 | Bottom | Bottom |

## Related
- Docs PR: lsportsltd/lsports-products-docs#72 (merged)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add 13 MMA and positional statuses to the <code>StatusDescription</code> enum so fight-outcome flows can expose the legacy mapped identifiers, and propagate the change through the changelog entry for Trade360SDK.Common.Entities v2.3.5.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>YakirZazon23</td><td>docs: mark Trade360SDK...</td><td>June 01, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>Bump Trade360SDK.Commo...</td><td>May 31, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/96?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>