### PR TITLE
TRGN-3848: Add MarketId to TransportMessageHeaders (v2.5.4 / v2.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Release Version 2.5.4]
+
+### [Trade360SDK.Common.Entities - v2.3.5]
+
+#### Added
+
+- **`TransportMessageHeaders`**: optional `MarketId` customer message header (TRGN-3848).
+
+### Backward Compatibility (v2.5.4)
+
+All changes are backward compatible. The new header is optional.
+
+---
+
 ## [Unreleased]
 
 ### Trade360SDK.Feed

--- a/src/Trade360SDK.Common.Entities/Models/TransportMessageHeaders.cs
+++ b/src/Trade360SDK.Common.Entities/Models/TransportMessageHeaders.cs
@@ -11,12 +11,14 @@ namespace Trade360SDK.Common.Models
         private const string TimestampInMsKey = "timestamp_in_ms";
         private const string MessageSequenceKey = "MessageSequence";
         private const string FixtureIdKey = "FixtureId";
+        private const string MarketIdKey = "MarketId";
         private const string SportIdKey = "SportId";
         
         public string MessageType { get; internal set; }
         public string MessageSequence { get; internal set; }
         public string MessageGuid { get; internal set; }
         public string FixtureId { get; internal set; }
+        public string MarketId { get; internal set; }
         public string SportId { get; internal set; }
         public string TimestampInMs { get; internal set; }
         
@@ -37,6 +39,7 @@ namespace Trade360SDK.Common.Models
                 TimestampInMs = GetRequiredProperty(properties, TimestampInMsKey),
                 MessageSequence = GetRequiredProperty(properties, MessageSequenceKey, false),
                 FixtureId = GetRequiredProperty(properties, FixtureIdKey, false),
+                MarketId = GetRequiredProperty(properties, MarketIdKey, false),
                 SportId = GetRequiredProperty(properties, SportIdKey, false)
             };
         }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.4</PackageVersion>
+		<PackageVersion>2.3.5</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -22,6 +22,7 @@
 			- 2.3.2 Added participant shirt color objects (ShirtColor, GoalKeeperShirtColor), added StatusDescription values 46-59, and added StartDate to OutrightLeagueFixture.
 			- 2.3.3 Made OutrightLeagueFixture.EndDate nullable to support null payloads.
 			- 2.3.4 Added NextFixtureStartTime to OutrightLeagueMarketUpdate (type 40) via OutrightLeagueMarketCompetitionWrapper.
+			- 2.3.5 Added optional MarketId customer message header to TransportMessageHeaders.
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Models/TransportMessageHeadersTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Models/TransportMessageHeadersTests.cs
@@ -16,6 +16,7 @@ public class TransportMessageHeadersTests
             { "MessageSequence", "123456789" },
             { "MessageGuid", "abc-def-123" },
             { "FixtureId", "fixture-456" },
+            { "MarketId", "market-202" },
             { "SportId", "sport-789" },
             { "timestamp_in_ms", "1640995200000" }
         };
@@ -29,6 +30,7 @@ public class TransportMessageHeadersTests
         result.MessageSequence.Should().Be("123456789");
         result.MessageGuid.Should().Be("abc-def-123");
         result.FixtureId.Should().Be("fixture-456");
+        result.MarketId.Should().Be("market-202");
         result.SportId.Should().Be("sport-789");
         result.TimestampInMs.Should().Be("1640995200000");
     }
@@ -131,6 +133,7 @@ public class TransportMessageHeadersTests
         var messageSequenceProperty = type.GetProperty(nameof(TransportMessageHeaders.MessageSequence));
         var messageGuidProperty = type.GetProperty(nameof(TransportMessageHeaders.MessageGuid));
         var fixtureIdProperty = type.GetProperty(nameof(TransportMessageHeaders.FixtureId));
+        var marketIdProperty = type.GetProperty(nameof(TransportMessageHeaders.MarketId));
         var sportIdProperty = type.GetProperty(nameof(TransportMessageHeaders.SportId));
 
         messageTypeProperty!.CanRead.Should().BeTrue();
@@ -144,6 +147,9 @@ public class TransportMessageHeadersTests
 
         fixtureIdProperty!.CanRead.Should().BeTrue();
         fixtureIdProperty.SetMethod!.IsAssembly.Should().BeTrue();
+
+        marketIdProperty!.CanRead.Should().BeTrue();
+        marketIdProperty.SetMethod!.IsAssembly.Should().BeTrue();
 
         sportIdProperty!.CanRead.Should().BeTrue();
         sportIdProperty.SetMethod!.IsAssembly.Should().BeTrue();
@@ -176,6 +182,7 @@ public class TransportMessageHeadersTests
         var messageGuidBytes = Encoding.UTF8.GetBytes("abc-def-123");
         var messageSequenceBytes = Encoding.UTF8.GetBytes("987654321");
         var fixtureIdBytes = Encoding.UTF8.GetBytes("fixture-789");
+        var marketIdBytes = Encoding.UTF8.GetBytes("market-202");
         var sportIdBytes = Encoding.UTF8.GetBytes("sport-456");
         
         var properties = new Dictionary<string, object>
@@ -184,6 +191,7 @@ public class TransportMessageHeadersTests
             { "MessageGuid", messageGuidBytes },
             { "MessageSequence", messageSequenceBytes },
             { "FixtureId", fixtureIdBytes },
+            { "MarketId", marketIdBytes },
             { "SportId", sportIdBytes },
             { "timestamp_in_ms", "1755778318057" }
         };
@@ -197,6 +205,7 @@ public class TransportMessageHeadersTests
         result.MessageGuid.Should().Be("abc-def-123");
         result.MessageSequence.Should().Be("987654321");
         result.FixtureId.Should().Be("fixture-789");
+        result.MarketId.Should().Be("market-202");
         result.SportId.Should().Be("sport-456");
         result.TimestampInMs.Should().Be("1755778318057");
     }
@@ -268,12 +277,14 @@ public class TransportMessageHeadersTests
         result.TimestampInMs.Should().Be("1640995200000");
         result.MessageSequence.Should().Be(string.Empty);
         result.FixtureId.Should().Be(string.Empty);
+        result.MarketId.Should().Be(string.Empty);
         result.SportId.Should().Be(string.Empty);
     }
 
     [Theory]
     [InlineData("MessageSequence")]
     [InlineData("FixtureId")]
+    [InlineData("MarketId")]
     [InlineData("SportId")]
     public void CreateFromProperties_WithNullOptionalProperty_ShouldUseEmptyString(string nullProperty)
     {
@@ -284,6 +295,7 @@ public class TransportMessageHeadersTests
             { "MessageGuid", "test-guid-123" },
             { "MessageSequence", "sequence-123" },
             { "FixtureId", "fixture-456" },
+            { "MarketId", "market-202" },
             { "SportId", "sport-789" },
             { "timestamp_in_ms", "1640995200000" }
         };
@@ -299,18 +311,28 @@ public class TransportMessageHeadersTests
         {
             result.MessageSequence.Should().Be(string.Empty);
             result.FixtureId.Should().Be("fixture-456");
+            result.MarketId.Should().Be("market-202");
             result.SportId.Should().Be("sport-789");
         }
         else if (nullProperty == "FixtureId")
         {
             result.MessageSequence.Should().Be("sequence-123");
             result.FixtureId.Should().Be(string.Empty);
+            result.MarketId.Should().Be("market-202");
+            result.SportId.Should().Be("sport-789");
+        }
+        else if (nullProperty == "MarketId")
+        {
+            result.MessageSequence.Should().Be("sequence-123");
+            result.FixtureId.Should().Be("fixture-456");
+            result.MarketId.Should().Be(string.Empty);
             result.SportId.Should().Be("sport-789");
         }
         else if (nullProperty == "SportId")
         {
             result.MessageSequence.Should().Be("sequence-123");
             result.FixtureId.Should().Be("fixture-456");
+            result.MarketId.Should().Be("market-202");
             result.SportId.Should().Be(string.Empty);
         }
     }


### PR DESCRIPTION
# User description
## Summary
- Add optional `MarketId` customer message header to `TransportMessageHeaders` in `Trade360SDK.Common.Entities`
- Bump `Trade360SDK.Common.Entities` to **v2.3.5** (release **v2.5.4**) and update changelog

Linear: https://linear.app/lsports-ltd/issue/TRGN-3848/add-marketid-to-sdks-part-of-customer-message-headers

## Test plan
- [x] `dotnet test test/Trade360SDK.Common.Entities.Tests --filter TransportMessageHeadersTests` (25/25 passing)
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional <code>MarketId</code> customer header to <code>TransportMessageHeaders</code> in <code>Trade360SDK.Common.Entities</code> so SDK messages can mirror fixture and sport identifier support. Document the v2.5.4/v2.3.5 release and note the new header addition in the changelog.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/97?tool=ast&topic=Release+notes>Release notes</a>
        </td><td>Document version 2.5.4 release and highlight the optional <code>MarketId</code> header addition in the changelog.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TRGN-3848: Add MarketI...</td><td>June 14, 2026</td></tr>
<tr><td>PavelTemno</td><td>add release notes</td><td>January 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/97?tool=ast&topic=MarketId+header>MarketId header</a>
        </td><td>Add optional <code>MarketId</code> to <code>TransportMessageHeaders</code>, propagating it through property creation so customer message headers can carry market identifiers.<details><summary>Modified files (1)</summary><ul><li>src/Trade360SDK.Common.Entities/Models/TransportMessageHeaders.cs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TRGN-3848: Add MarketI...</td><td>June 14, 2026</td></tr>
<tr><td>Phil1903</td><td>Added SportId rmq head...</td><td>January 18, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/97?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>