### PR TITLE
PRD-1516: .NET SDK Market Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Release Version 2.5.5]
+
+Adds authoritative market-level status on Market and ProviderMarket messages (PRD-1516).
+
+### [Trade360SDK.Common.Entities - v2.3.6]
+
+#### Added
+
+- **`MarketStatus`** enum (`NotSet`, `Open`, `Suspended`, `Settled`) for market-level status values.
+- **`Market.Status`**: maps JSON `Status` on calculated market payloads (1=Open, 2=Suspended, 3=Settled).
+- **`ProviderMarket.MarketStatus`**: maps JSON `MarketStatus` on provider market payloads from the feed.
+
+### Backward Compatibility (v2.5.5)
+
+All changes are backward compatible. New properties default to `NotSet` (0) when absent from the payload.
+
+---
+
 ## [Release Version 2.5.4]
 
 ### [Trade360SDK.Common.Entities - v2.3.5]

--- a/src/Trade360SDK.Common.Entities/Entities/Enums/MarketStatus.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Enums/MarketStatus.cs
@@ -1,0 +1,10 @@
+namespace Trade360SDK.Common.Entities.Enums
+{
+    public enum MarketStatus
+    {
+        NotSet = 0,
+        Open = 1,
+        Suspended = 2,
+        Settled = 3
+    }
+}

--- a/src/Trade360SDK.Common.Entities/Entities/Markets/Market.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Markets/Market.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Trade360SDK.Common.Entities.Enums;
 
 namespace Trade360SDK.Common.Entities.Markets
 {
@@ -13,5 +14,7 @@ namespace Trade360SDK.Common.Entities.Markets
         public IEnumerable<ProviderMarket>? ProviderMarkets { get; set; }
 
         public string? MainLine { get; set; }
+
+        public MarketStatus Status { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/Markets/ProviderMarket.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Markets/ProviderMarket.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Trade360SDK.Common.Entities.Enums;
 
 namespace Trade360SDK.Common.Entities.Markets
 {
@@ -12,5 +13,7 @@ namespace Trade360SDK.Common.Entities.Markets
         public IEnumerable<ProviderBet>? Bets { get; set; }
 
         public DateTime LastUpdate { get; set; }
+
+        public MarketStatus MarketStatus { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.5</PackageVersion>
+		<PackageVersion>2.3.6</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -23,6 +23,7 @@
 			- 2.3.3 Made OutrightLeagueFixture.EndDate nullable to support null payloads.
 			- 2.3.4 Added NextFixtureStartTime to OutrightLeagueMarketUpdate (type 40) via OutrightLeagueMarketCompetitionWrapper.
 			- 2.3.5 Added optional MarketId customer message header to TransportMessageHeaders.
+			- 2.3.6 Added MarketStatus enum and Status property on Market entity (PRD-1516).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/MarketTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/MarketTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Text.Json;
+using Trade360SDK.Common.Entities.Enums;
 using Trade360SDK.Common.Entities.Markets;
 using Xunit;
 
@@ -35,5 +37,16 @@ namespace Trade360SDK.Common.Tests
             Assert.Null(market.ProviderMarkets);
             Assert.Null(market.MainLine);
         }
+
+        [Fact]
+        public void DeserializeMarketStatusFromJson_MapsStatusProperty()
+        {
+            var market = JsonSerializer.Deserialize<Market>("{\"Id\":52,\"Name\":\"1X2\",\"Status\":2,\"Bets\":[]}");
+
+            Assert.NotNull(market);
+            Assert.Equal(52, market!.Id);
+            Assert.Equal("1X2", market.Name);
+            Assert.Equal(MarketStatus.Suspended, market.Status);
+        }
     }
-} 
+}

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/ProviderMarketTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/ProviderMarketTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using Trade360SDK.Common.Entities.Enums;
 using Trade360SDK.Common.Entities.Markets;
 using Xunit;
 
@@ -30,6 +32,18 @@ namespace Trade360SDK.Common.Tests
             var market = new ProviderMarket();
             Assert.Null(market.Name);
             Assert.Null(market.Bets);
+        }
+
+        [Fact]
+        public void DeserializeMarketStatusFromJson_MapsMarketStatusProperty()
+        {
+            var providerMarket = JsonSerializer.Deserialize<ProviderMarket>(
+                "{\"Id\":57,\"Name\":\"Bet365\",\"MarketStatus\":2,\"Bets\":[]}");
+
+            Assert.NotNull(providerMarket);
+            Assert.Equal(57, providerMarket!.Id);
+            Assert.Equal("Bet365", providerMarket.Name);
+            Assert.Equal(MarketStatus.Suspended, providerMarket.MarketStatus);
         }
     }
 } 


### PR DESCRIPTION
# User description
## Summary
- Add authoritative customer-facing `Status` on Trade360 market objects (1=Open, 2=Suspended, 3=Settled), computed from the full calculated bet set after TRADE rules — never DI passthrough.
- Includes unit tests for rollup logic, status-only delta distribution, and wire/SDK mapping where applicable.

JIRA: https://lsports-data.atlassian.net/browse/PRD-1516

## Deploy order (pipeline)
Refiner → Calculator → Distributors → Logger/Snapshot → SDKs

## Test plan
- [x] Unit tests added/updated for Market Status behavior
- [ ] QA validation (TRGN-3952)

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce the <code>MarketStatus</code> enum and expose the mapped status on <code>Market</code> and <code>ProviderMarket</code> so SDK consumers receive authoritative market-level states derived from calculated payloads. Document the release and backward-compatibility details for the new status fields in the changelog.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/98?tool=ast&topic=Release+Notes>Release Notes</a>
        </td><td>Document the new status feature and compatibility notes for Release Version 2.5.5.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ortal@lsports.eu</td><td>Document MarketStatus ...</td><td>July 13, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>Add MarketId to Transp...</td><td>June 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/98?tool=ast&topic=Market+Status+Fields>Market Status Fields</a>
        </td><td>Map <code>MarketStatus</code> into calculated and provider markets so <code>Market.Status</code> and <code>ProviderMarket.MarketStatus</code> reflect the authoritative open/suspended/settled state.<details><summary>Modified files (3)</summary><ul><li>src/Trade360SDK.Common.Entities/Entities/Enums/MarketStatus.cs</li>
<li>src/Trade360SDK.Common.Entities/Entities/Markets/Market.cs</li>
<li>src/Trade360SDK.Common.Entities/Entities/Markets/ProviderMarket.cs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ortal@lsports.eu</td><td>Add MarketStatus to Pr...</td><td>July 12, 2026</td></tr>
<tr><td>PavelTemno</td><td>Add ProviderMarkets, c...</td><td>January 07, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/98?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>