### PR TITLE
Add MarketStatus to ProviderMarket entity.

### DIFF
--- a/src/Trade360SDK.Common.Entities/Entities/Markets/ProviderMarket.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Markets/ProviderMarket.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Trade360SDK.Common.Entities.Enums;
 
 namespace Trade360SDK.Common.Entities.Markets
 {
@@ -12,5 +13,7 @@ namespace Trade360SDK.Common.Entities.Markets
         public IEnumerable<ProviderBet>? Bets { get; set; }
 
         public DateTime LastUpdate { get; set; }
+
+        public MarketStatus MarketStatus { get; set; }
     }
 }

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/ProviderMarketTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/ProviderMarketTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using Trade360SDK.Common.Entities.Enums;
 using Trade360SDK.Common.Entities.Markets;
 using Xunit;
 
@@ -30,6 +32,18 @@ namespace Trade360SDK.Common.Tests
             var market = new ProviderMarket();
             Assert.Null(market.Name);
             Assert.Null(market.Bets);
+        }
+
+        [Fact]
+        public void DeserializeMarketStatusFromJson_MapsMarketStatusProperty()
+        {
+            var providerMarket = JsonSerializer.Deserialize<ProviderMarket>(
+                "{\"Id\":57,\"Name\":\"Bet365\",\"MarketStatus\":2,\"Bets\":[]}");
+
+            Assert.NotNull(providerMarket);
+            Assert.Equal(57, providerMarket!.Id);
+            Assert.Equal("Bet365", providerMarket.Name);
+            Assert.Equal(MarketStatus.Suspended, providerMarket.MarketStatus);
         }
     }
 } 


### PR DESCRIPTION
# User description
Expose per-provider market status on the SDK contract so customers can deserialize ProviderMarkets MarketStatus from the feed.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose <code>MarketStatus</code> from <code>ProviderMarket</code> so the SDK provides per-provider status through the feed. Extend <code>ProviderMarket</code> tests to ensure JSON deserializes the new <code>MarketStatus</code> property correctly.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ortal@lsports.eu</td><td>Add MarketStatus to Pr...</td><td>July 12, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>Add unit tests for Tra...</td><td>June 16, 2025</td></tr></table></details>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/99?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>