### PR TITLE
PRD-1516: ProviderMarket.marketStatus and RMQ Market Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`Market.Status`**: RMQ JSON field is `Status` on calculated market payloads (PRD-1516).
+
+---
+
 ## [Release Version 2.5.5]
 
 Adds authoritative market-level status on Market and ProviderMarket messages (PRD-1516).
@@ -14,7 +22,7 @@ Adds authoritative market-level status on Market and ProviderMarket messages (PR
 #### Added
 
 - **`MarketStatus`** enum (`NotSet`, `Open`, `Suspended`, `Settled`) for market-level status values.
-- **`Market.Status`**: maps JSON `MarketStatus` on market payloads (1=Open, 2=Suspended, 3=Settled); also accepts settlement JSON `Status`.
+- **`Market.Status`**: maps JSON `Status` on RMQ market payloads (1=Open, 2=Suspended, 3=Settled).
 - **`ProviderMarket.MarketStatus`**: maps JSON `MarketStatus` on provider market payloads from the feed.
 
 ### Backward Compatibility (v2.5.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Adds authoritative market-level status on Market and ProviderMarket messages (PR
 #### Added
 
 - **`MarketStatus`** enum (`NotSet`, `Open`, `Suspended`, `Settled`) for market-level status values.
-- **`Market.Status`**: maps JSON `Status` on calculated market payloads (1=Open, 2=Suspended, 3=Settled).
+- **`Market.Status`**: maps JSON `MarketStatus` on market payloads (1=Open, 2=Suspended, 3=Settled); also accepts settlement JSON `Status`.
 - **`ProviderMarket.MarketStatus`**: maps JSON `MarketStatus` on provider market payloads from the feed.
 
 ### Backward Compatibility (v2.5.5)

--- a/src/Trade360SDK.Common.Entities/Entities/Markets/Market.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Markets/Market.cs
@@ -16,13 +16,7 @@ namespace Trade360SDK.Common.Entities.Markets
 
         public string? MainLine { get; set; }
 
-        [JsonPropertyName("MarketStatus")]
-        public MarketStatus Status { get; set; }
-
         [JsonPropertyName("Status")]
-        public MarketStatus SettlementStatusAlias
-        {
-            set => Status = value;
-        }
+        public MarketStatus Status { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/Markets/Market.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Markets/Market.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Trade360SDK.Common.Entities.Enums;
 
 namespace Trade360SDK.Common.Entities.Markets
@@ -15,6 +16,13 @@ namespace Trade360SDK.Common.Entities.Markets
 
         public string? MainLine { get; set; }
 
+        [JsonPropertyName("MarketStatus")]
         public MarketStatus Status { get; set; }
+
+        [JsonPropertyName("Status")]
+        public MarketStatus SettlementStatusAlias
+        {
+            set => Status = value;
+        }
     }
 }

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/MarketTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/MarketTests.cs
@@ -48,14 +48,5 @@ namespace Trade360SDK.Common.Tests
             Assert.Equal("1X2", market.Name);
             Assert.Equal(MarketStatus.Suspended, market.Status);
         }
-
-        [Fact]
-        public void DeserializeMarketStatusFromJson_MapsMarketStatusProperty()
-        {
-            var market = JsonSerializer.Deserialize<Market>("{\"Id\":52,\"Name\":\"1X2\",\"MarketStatus\":2,\"Bets\":[]}");
-
-            Assert.NotNull(market);
-            Assert.Equal(MarketStatus.Suspended, market!.Status);
-        }
     }
 }

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/MarketTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Markets/MarketTests.cs
@@ -48,5 +48,14 @@ namespace Trade360SDK.Common.Tests
             Assert.Equal("1X2", market.Name);
             Assert.Equal(MarketStatus.Suspended, market.Status);
         }
+
+        [Fact]
+        public void DeserializeMarketStatusFromJson_MapsMarketStatusProperty()
+        {
+            var market = JsonSerializer.Deserialize<Market>("{\"Id\":52,\"Name\":\"1X2\",\"MarketStatus\":2,\"Bets\":[]}");
+
+            Assert.NotNull(market);
+            Assert.Equal(MarketStatus.Suspended, market!.Status);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `ProviderMarket.MarketStatus` for per-provider status on markets feed
- RMQ calculated `Market.Status` deserializes JSON `Status` only (aligned with settlement/markets distributors)

JIRA: https://lsports-data.atlassian.net/browse/PRD-1516

Follow-up to #98 (ProviderMarket.MarketStatus + calculated status).

## Test plan
- [x] `MarketTests` Status deserialization
- [x] `ProviderMarketTests` MarketStatus deserialization