### PR TITLE
feat: add StatusDescription values 60-72 (TRGN-3981)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Release Version 2.5.6]
+
+### [Trade360SDK.Common.Entities - v2.3.7]
+
+#### Added
+
+- **`StatusDescription`**: 13 new MMA/fight-outcome and positional enum values (TRGN-3981) — `Fighter1Disqualification` (60), `Fighter2Disqualification` (61), `Fighter1MajorityDecision` (62), `Fighter2MajorityDecision` (63), `Fighter1UnanimousDecision` (64), `Fighter2UnanimousDecision` (65), `Fighter1Submission` (66), `Fighter2Submission` (67), `Fighter1KoTko` (68), `Fighter2KoTko` (69), `NoContest` (70), `Top` (71), `Bottom` (72).
+
+### Backward Compatibility (v2.5.6)
+
+All changes are backward compatible. New enum values are additive.
+
+---
+
 ## [Release Version 2.5.5]
 
 Adds authoritative market-level status on Market and ProviderMarket messages (PRD-1516).

--- a/src/Trade360SDK.Common.Entities/Entities/Enums/StatusDescription.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Enums/StatusDescription.cs
@@ -61,6 +61,19 @@
         WaitingForPenalties = 56,
         EnteringExtraTime = 57,
         ExtraTimeBreak = 58,
-        EnteringPenaltyShootout = 59
+        EnteringPenaltyShootout = 59,
+        Fighter1Disqualification = 60,
+        Fighter2Disqualification = 61,
+        Fighter1MajorityDecision = 62,
+        Fighter2MajorityDecision = 63,
+        Fighter1UnanimousDecision = 64,
+        Fighter2UnanimousDecision = 65,
+        Fighter1Submission = 66,
+        Fighter2Submission = 67,
+        Fighter1KoTko = 68,
+        Fighter2KoTko = 69,
+        NoContest = 70,
+        Top = 71,
+        Bottom = 72
     }
 }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.6</PackageVersion>
+		<PackageVersion>2.3.7</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -24,6 +24,7 @@
 			- 2.3.4 Added NextFixtureStartTime to OutrightLeagueMarketUpdate (type 40) via OutrightLeagueMarketCompetitionWrapper.
 			- 2.3.5 Added optional MarketId customer message header to TransportMessageHeaders.
 			- 2.3.6 Added MarketStatus enum and Status property on Market entity (PRD-1516).
+			- 2.3.7 Added 13 MMA/fight-outcome and positional StatusDescription enum values (IDs 60-72) (TRGN-3981).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/Enums/StatusDescriptionTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/Enums/StatusDescriptionTests.cs
@@ -68,6 +68,19 @@ namespace Trade360SDK.Common.Tests.Entities.Enums
             Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.EnteringExtraTime));
             Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.ExtraTimeBreak));
             Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.EnteringPenaltyShootout));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1Disqualification));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2Disqualification));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1MajorityDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2MajorityDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1UnanimousDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2UnanimousDecision));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1Submission));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2Submission));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter1KoTko));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Fighter2KoTko));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.NoContest));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Top));
+            Assert.True(System.Enum.IsDefined(typeof(StatusDescription), StatusDescription.Bottom));
         }
     }
-} 
+}


### PR DESCRIPTION
# User description
## Summary
- Adds 13 MMA/fight-outcome and positional `StatusDescription` enum values (IDs 60–72)
- Bumps `Trade360SDK.Common.Entities` to **2.3.7** and documents Release Version 2.5.6
- Replaces closed stale PR #96 (DIN-23830) which targeted superseded version 2.3.5

## New values
| Id | Name |
| --- | --- |
| 60 | Fighter1Disqualification |
| 61 | Fighter2Disqualification |
| 62 | Fighter1MajorityDecision |
| 63 | Fighter2MajorityDecision |
| 64 | Fighter1UnanimousDecision |
| 65 | Fighter2UnanimousDecision |
| 66 | Fighter1Submission |
| 67 | Fighter2Submission |
| 68 | Fighter1KoTko |
| 69 | Fighter2KoTko |
| 70 | NoContest |
| 71 | Top |
| 72 | Bottom |

## Test plan
- [x] `StatusDescriptionTests` pass
- [ ] CI green on this PR

Related: TRGN-3981

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose the thirteen new MMA/fight-outcome and positional <code>StatusDescription</code> values so clients receive the distributor&#x27;s expanded status IDs while keeping serialization intact. Document the <code>Trade360SDK.Common.Entities</code> 2.3.7 release and changelog so consumers understand the new SDK version that ships the enum additions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/101?tool=ast&topic=StatusDescription>StatusDescription</a>
        </td><td>Add the thirteen new MMA/fight-outcome and positional status values to the enum and confirm they exist via <code>StatusDescriptionTests</code>.<details><summary>Modified files (2)</summary><ul><li>src/Trade360SDK.Common.Entities/Entities/Enums/StatusDescription.cs</li>
<li>test/Trade360SDK.Common.Entities.Tests/Entities/Enums/StatusDescriptionTests.cs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>feat: add StatusDescri...</td><td>July 14, 2026</td></tr>
<tr><td>noammerLS</td><td>Added additional value...</td><td>July 06, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/101?tool=ast&topic=Release+metadata>Release metadata</a>
        </td><td>Document the resulting 2.3.7 package release in the project metadata and changelog so consumers know about the new status values.<details><summary>Modified files (2)</summary><ul><li>CHANGELOG.md</li>
<li>src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>feat: add StatusDescri...</td><td>July 14, 2026</td></tr>
<tr><td>ortal@lsports.eu</td><td>RMQ Market deserialize...</td><td>July 13, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/101?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>