### PR TITLE
TRGN-3934: Expose HeartbeatUpdate.Problem (.NET SDK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Release Version 2.5.8]
+
+### [Trade360SDK.Common.Entities - v2.3.9]
+
+#### Added
+
+- **`HeartbeatUpdate.FeedInterrupted`**: optional feed interruption signal on type-32 heartbeat body (`0` = normal, non-zero = interrupted). Signal only — does not trigger auto-suspend or recovery (TRGN-3934).
+
+### Backward Compatibility (v2.5.8)
+
+All changes are backward compatible. `FeedInterrupted` is optional and defaults to `0` when absent from the payload.
+
+---
+
 ## [Release Version 2.5.7]
 
 ### [Trade360SDK.Common.Entities - v2.3.8]

--- a/src/Trade360SDK.Common.Entities/Entities/MessageTypes/HeartbeatUpdate.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/MessageTypes/HeartbeatUpdate.cs
@@ -5,5 +5,10 @@ namespace Trade360SDK.Common.Entities.MessageTypes
     [Trade360Entity(32)]
     public class HeartbeatUpdate : MessageUpdate
     {
+        /// <summary>
+        /// Feed health signal. 0 = no problem (default), non-zero = problem detected upstream.
+        /// Signal only — does not trigger auto-suspend or recovery.
+        /// </summary>
+        public int Problem { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/MessageTypes/HeartbeatUpdate.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/MessageTypes/HeartbeatUpdate.cs
@@ -1,4 +1,4 @@
-﻿using Trade360SDK.Common.Attributes;
+using Trade360SDK.Common.Attributes;
 
 namespace Trade360SDK.Common.Entities.MessageTypes
 {
@@ -6,9 +6,9 @@ namespace Trade360SDK.Common.Entities.MessageTypes
     public class HeartbeatUpdate : MessageUpdate
     {
         /// <summary>
-        /// Feed health signal. 0 = no problem (default), non-zero = problem detected upstream.
+        /// Feed interruption signal. 0 = normal (default), non-zero = feed interrupted upstream.
         /// Signal only — does not trigger auto-suspend or recovery.
         /// </summary>
-        public int Problem { get; set; }
+        public int FeedInterrupted { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.8</PackageVersion>
+		<PackageVersion>2.3.9</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -26,6 +26,7 @@
 			- 2.3.6 Added MarketStatus enum and Status property on Market entity (PRD-1516).
 			- 2.3.7 Added 13 MMA/fight-outcome and positional StatusDescription enum values (IDs 60-72) (TRGN-3981).
 			- 2.3.8 Added MarketPredictionData (volume only) on Market and ProviderMarket, and BetPredictionData (volume, liquidity, startDate, endDate) on BaseBet (PRD-1516).
+			- 2.3.9 Added FeedInterrupted on HeartbeatUpdate (entity 32) for feed interruption signal (TRGN-3934).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/HeartbeatUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/HeartbeatUpdateTests.cs
@@ -15,11 +15,11 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
         };
 
         [Fact]
-        public void Problem_ShouldDefaultToZero()
+        public void FeedInterrupted_ShouldDefaultToZero()
         {
             var update = new HeartbeatUpdate();
 
-            update.Problem.Should().Be(0);
+            update.FeedInterrupted.Should().Be(0);
         }
 
         [Fact]
@@ -27,10 +27,10 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
         {
             var update = new HeartbeatUpdate
             {
-                Problem = 1
+                FeedInterrupted = 1
             };
 
-            update.Problem.Should().Be(1);
+            update.FeedInterrupted.Should().Be(1);
         }
 
         [Fact]
@@ -43,36 +43,36 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
         }
 
         [Fact]
-        public void JsonDeserialization_WithProblemInBody_ShouldPopulateProblem()
+        public void JsonDeserialization_WithFeedInterruptedInBody_ShouldPopulate()
         {
-            const string body = "{\"Problem\":1}";
+            const string body = "{\"FeedInterrupted\":1}";
 
             var result = JsonSerializer.Deserialize<HeartbeatUpdate>(body, FeedJsonOptions);
 
             result.Should().NotBeNull();
-            result!.Problem.Should().Be(1);
+            result!.FeedInterrupted.Should().Be(1);
         }
 
         [Fact]
-        public void JsonDeserialization_WithoutProblemInBody_ShouldDefaultToZero()
+        public void JsonDeserialization_WithoutFeedInterruptedInBody_ShouldDefaultToZero()
         {
             const string body = "{}";
 
             var result = JsonSerializer.Deserialize<HeartbeatUpdate>(body, FeedJsonOptions);
 
             result.Should().NotBeNull();
-            result!.Problem.Should().Be(0);
+            result!.FeedInterrupted.Should().Be(0);
         }
 
         [Fact]
-        public void JsonDeserialization_WithLowercaseProblemInBody_ShouldPopulateProblem()
+        public void JsonDeserialization_WithCamelCaseFeedInterrupted_ShouldPopulate()
         {
-            const string body = "{\"problem\":1}";
+            const string body = "{\"feedInterrupted\":1}";
 
             var result = JsonSerializer.Deserialize<HeartbeatUpdate>(body, FeedJsonOptions);
 
             result.Should().NotBeNull();
-            result!.Problem.Should().Be(1);
+            result!.FeedInterrupted.Should().Be(1);
         }
     }
 }

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/HeartbeatUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/HeartbeatUpdateTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using FluentAssertions;
+using Trade360SDK.Common.Attributes;
+using Trade360SDK.Common.Entities.MessageTypes;
+using Xunit;
+
+namespace Trade360SDK.Common.Tests.Entities.MessageTypes
+{
+    public class HeartbeatUpdateTests
+    {
+        private static readonly JsonSerializerOptions FeedJsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        [Fact]
+        public void Problem_ShouldDefaultToZero()
+        {
+            var update = new HeartbeatUpdate();
+
+            update.Problem.Should().Be(0);
+        }
+
+        [Fact]
+        public void Properties_ShouldGetAndSetValues()
+        {
+            var update = new HeartbeatUpdate
+            {
+                Problem = 1
+            };
+
+            update.Problem.Should().Be(1);
+        }
+
+        [Fact]
+        public void HeartbeatUpdate_ShouldHaveTrade360EntityAttributeWithKey32()
+        {
+            var attributes = typeof(HeartbeatUpdate).GetCustomAttributes(typeof(Trade360EntityAttribute), false);
+
+            attributes.Should().HaveCount(1);
+            ((Trade360EntityAttribute)attributes[0]).EntityKey.Should().Be(32);
+        }
+
+        [Fact]
+        public void JsonDeserialization_WithProblemInBody_ShouldPopulateProblem()
+        {
+            const string body = "{\"Problem\":1}";
+
+            var result = JsonSerializer.Deserialize<HeartbeatUpdate>(body, FeedJsonOptions);
+
+            result.Should().NotBeNull();
+            result!.Problem.Should().Be(1);
+        }
+
+        [Fact]
+        public void JsonDeserialization_WithoutProblemInBody_ShouldDefaultToZero()
+        {
+            const string body = "{}";
+
+            var result = JsonSerializer.Deserialize<HeartbeatUpdate>(body, FeedJsonOptions);
+
+            result.Should().NotBeNull();
+            result!.Problem.Should().Be(0);
+        }
+
+        [Fact]
+        public void JsonDeserialization_WithLowercaseProblemInBody_ShouldPopulateProblem()
+        {
+            const string body = "{\"problem\":1}";
+
+            var result = JsonSerializer.Deserialize<HeartbeatUpdate>(body, FeedJsonOptions);
+
+            result.Should().NotBeNull();
+            result!.Problem.Should().Be(1);
+        }
+    }
+}


### PR DESCRIPTION
# User description
## Summary
- Add `Problem` on Trade360 .NET `HeartbeatUpdate`
- Unit coverage for serialize/deserialize

## Linear
https://linear.app/lsports-ltd/issue/TRGN-3934

## Test plan
- [ ] HeartbeatUpdateTests green


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose <code>HeartbeatUpdate.FeedInterrupted</code> on the .NET <code>HeartbeatUpdate</code> entity so heartbeat payloads can carry feed interruption signals without adding recovery behavior. Update the changelog to document the backward-compatible addition and its default <code>0</code> value when the field is absent.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gal.be@lsports.eu</td><td>Expose HeartbeatUpdate...</td><td>July 28, 2026</td></tr>
<tr><td>ortal@lsports.eu</td><td>Merge main into _predi...</td><td>July 22, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/104?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>