### PR TITLE
feat: add FixtureName to OutrightLeague market/settlement events (TRGN-1739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Release Version 2.5.9]
+
+### [Trade360SDK.Common.Entities - v2.3.10]
+
+#### Added
+
+- **`OutrightLeagueMarketEvent.FixtureName`**: optional fixture name on nested events in OutrightLeagueMarketUpdate (type 40) and OutrightLeagueSettlementUpdate (type 43). Omitted when absent from the payload (TRGN-1739).
+
+### Backward Compatibility (v2.5.9)
+
+All changes are backward compatible. `FixtureName` is optional and remains `null` when absent from the payload.
+
+---
+
 ## [Release Version 2.5.8]
 
 ### [Trade360SDK.Common.Entities - v2.3.9]

--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketEvent.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketEvent.cs
@@ -1,11 +1,21 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Trade360SDK.Common.Entities.OutrightLeague
 {
     public class OutrightLeagueMarketEvent
     {
         public int FixtureId { get; set; }
-        public string? FixtureName { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? FixtureName
+        {
+            get => _fixtureName;
+            set => _fixtureName = string.IsNullOrEmpty(value) ? null : value;
+        }
+
         public IEnumerable<MarketLeague>? Markets { get; set; }
+
+        private string? _fixtureName;
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketEvent.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketEvent.cs
@@ -5,6 +5,7 @@ namespace Trade360SDK.Common.Entities.OutrightLeague
     public class OutrightLeagueMarketEvent
     {
         public int FixtureId { get; set; }
+        public string? FixtureName { get; set; }
         public IEnumerable<MarketLeague>? Markets { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.9</PackageVersion>
+		<PackageVersion>2.3.10</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -27,6 +27,7 @@
 			- 2.3.7 Added 13 MMA/fight-outcome and positional StatusDescription enum values (IDs 60-72) (TRGN-3981).
 			- 2.3.8 Added MarketPredictionData (volume only) on Market and ProviderMarket, and BetPredictionData (volume, liquidity, startDate, endDate) on BaseBet (PRD-1516).
 			- 2.3.9 Added FeedInterrupted on HeartbeatUpdate (entity 32) for feed interruption signal (TRGN-3934).
+			- 2.3.10 Added FixtureName to OutrightLeagueMarketEvent for message types 40 and 43 (TRGN-1739).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
@@ -57,6 +57,7 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
 
             var marketEvent = season.Events!.Single();
             marketEvent.FixtureId.Should().Be(26721036);
+            marketEvent.FixtureName.Should().Be("Premier League 2023/2024 Outright Winner");
             marketEvent.Markets.Should().HaveCount(1);
 
             var market = marketEvent.Markets!.Single();

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueSettlementUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueSettlementUpdateTests.cs
@@ -88,6 +88,7 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
                             ""Events"": [
                                 {
                                     ""FixtureId"": 24603148,
+                                    ""FixtureName"": ""Premier League 2023/2024 Outright Winner"",
                                     ""Markets"": [
                                         {
                                             ""Id"": 274,
@@ -152,6 +153,7 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
             // Market event level assertions
             var marketEvent = eventsWrapper.Events!.First();
             marketEvent.FixtureId.Should().Be(24603148);
+            marketEvent.FixtureName.Should().Be("Premier League 2023/2024 Outright Winner");
             marketEvent.Markets.Should().NotBeNull();
             marketEvent.Markets.Should().HaveCount(1);
             

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketEventTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketEventTests.cs
@@ -13,9 +13,11 @@ namespace Trade360SDK.Common.Tests
             var evt = new OutrightLeagueMarketEvent
             {
                 FixtureId = 123,
+                FixtureName = "Premier League 2023/2024 Outright Winner",
                 Markets = markets
             };
             Assert.Equal(123, evt.FixtureId);
+            Assert.Equal("Premier League 2023/2024 Outright Winner", evt.FixtureName);
             Assert.Equal(markets, evt.Markets);
         }
 
@@ -24,6 +26,7 @@ namespace Trade360SDK.Common.Tests
         {
             var evt = new OutrightLeagueMarketEvent();
             Assert.Equal(0, evt.FixtureId); // default int
+            Assert.Null(evt.FixtureName);
             Assert.Null(evt.Markets);
         }
     }

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketEventTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueMarketEventTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using Trade360SDK.Common.Entities.OutrightLeague;
 using Xunit;
 
@@ -28,6 +29,49 @@ namespace Trade360SDK.Common.Tests
             Assert.Equal(0, evt.FixtureId); // default int
             Assert.Null(evt.FixtureName);
             Assert.Null(evt.Markets);
+        }
+
+        [Fact]
+        public void FixtureName_EmptyOrWhitespace_ShouldNormalizeToNull()
+        {
+            var evt = new OutrightLeagueMarketEvent
+            {
+                FixtureName = ""
+            };
+            Assert.Null(evt.FixtureName);
+
+            evt.FixtureName = "Premier League 2023/2024 Outright Winner";
+            evt.FixtureName = null;
+            Assert.Null(evt.FixtureName);
+        }
+
+        [Fact]
+        public void JsonSerialization_WhenFixtureNameNull_ShouldOmitProperty()
+        {
+            var evt = new OutrightLeagueMarketEvent
+            {
+                FixtureId = 24603148,
+                FixtureName = null
+            };
+
+            var json = JsonSerializer.Serialize(evt);
+
+            Assert.DoesNotContain("FixtureName", json);
+            Assert.Contains("\"FixtureId\":24603148", json);
+        }
+
+        [Fact]
+        public void JsonSerialization_WhenFixtureNamePresent_ShouldIncludeProperty()
+        {
+            var evt = new OutrightLeagueMarketEvent
+            {
+                FixtureId = 24603148,
+                FixtureName = "Premier League 2023/2024 Outright Winner"
+            };
+
+            var json = JsonSerializer.Serialize(evt);
+
+            Assert.Contains("\"FixtureName\":\"Premier League 2023/2024 Outright Winner\"", json);
         }
     }
 } 

--- a/test/Trade360SDK.Common.Entities.Tests/Fixtures/outright-league-market-update-type40.json
+++ b/test/Trade360SDK.Common.Entities.Tests/Fixtures/outright-league-market-update-type40.json
@@ -12,6 +12,7 @@
         "Events": [
           {
             "FixtureId": 26721036,
+            "FixtureName": "Premier League 2023/2024 Outright Winner",
             "Livescore": null,
             "Markets": [
               {


### PR DESCRIPTION
# User description
## Summary
- Add optional `FixtureName` on `OutrightLeagueMarketEvent` for message types **40** (`OutrightLeagueMarketUpdate`) and **43** (`OutrightLeagueSettlementUpdate`)
- Bump `Trade360SDK.Common.Entities` to **2.3.10** / release **2.5.9**
- Update changelog, fixtures, and unit tests

Linear: [TRGN-1739](https://linear.app/lsports-ltd/issue/TRGN-1739/sdk-add-fixture-name-to-outrightleaguemarketsettlement-messages)

## Test plan
- [x] `OutrightLeagueMarketEvent` / type 40 / type 43 entity tests pass
- [ ] Verify deserialization of production payload with `FixtureName` present
- [ ] Verify field remains null when omitted from payload


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional <code>FixtureName</code> handling to <code>OutrightLeagueMarketEvent</code>, which represents nested events for OutrightLeague market and settlement messages (types 40 and 43), so all sports can expose fixture names while preserving compatibility when absent. Update release documentation and version metadata to describe the new field and its omission behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/108?tool=ast&topic=Fixture+Name+Support>Fixture Name Support</a>
        </td><td>Expose <code>FixtureName</code> on OutrightLeague market and settlement events, normalizing empty values to <code>null</code> and omitting missing values during JSON serialization.<details><summary>Modified files (1)</summary><ul><li>src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketEvent.cs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix: omit FixtureName ...</td><td>August 05, 2026</td></tr>
<tr><td>itsikha@gmail.com</td><td>Tests outright, fix ge...</td><td>July 25, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/108?tool=ast&topic=Release+Documentation>Release Documentation</a>
        </td><td>Document the new optional field, backward-compatible behavior, and updated SDK package release.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>feat: add FixtureName ...</td><td>August 05, 2026</td></tr>
<tr><td>gal.be@lsports.eu</td><td>fix: use Array.Empty f...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/108?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>