### PR TITLE
fix: allow NetworkRecoveryInterval 0; sample 5s (TRGN-4200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- **`NetworkRecoveryInterval`**: allowed range lowered so customers can set **5** seconds (previous effective minimum was 16). Values must be between **5** and **4,294,967** seconds (upper bound keeps recovery delays within RabbitMQ.Client `Task.Delay` limits). Sample may use `5` or `30` (TRGN-4200).
+- **`NetworkRecoveryInterval`**: sample config is **5** seconds. Allowed range is **0–4,294,967** seconds (`0` permitted for immediate retry; upper bound keeps delays within RabbitMQ.Client `Task.Delay` limits). Previous effective minimum was 16 (TRGN-4200).
 
 ### Backward Compatibility (v2.5.10)
 
-Backward compatible for omitted and `30` configs: the property default remains **30** seconds. Explicit values below **5**, zero, negative, or above **4,294,967** are rejected at validation.
+Backward compatible for omitted and `30` configs: the property default remains **30** seconds. Sample uses **5**. Explicit negative values or values above **4,294,967** are rejected; **0** and **5** are accepted.
 ---
 
 ## [Release Version 2.5.9]

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ For **plain AMQP** (no TLS), use port **5672** and `"SslEnabled": false`. For **
       "PrefetchCount": 100,
       "AutoAck": false,
       "RequestedHeartbeatSeconds": 30,
-      "NetworkRecoveryInterval": 30,
+      "NetworkRecoveryInterval": 5,
       "DispatchConsumersAsync": true,
       "AutomaticRecoveryEnabled": true
     },
@@ -607,7 +607,7 @@ For **plain AMQP** (no TLS), use port **5672** and `"SslEnabled": false`. For **
       "PrefetchCount": 100,
       "AutoAck": false,
       "RequestedHeartbeatSeconds": 30,
-      "NetworkRecoveryInterval": 30,
+      "NetworkRecoveryInterval": 5,
       "DispatchConsumersAsync": true,
       "AutomaticRecoveryEnabled": true
     }
@@ -1293,7 +1293,7 @@ services.AddOpenTelemetry()
       "PrefetchCount": 100,
       "AutoAck": false,
       "RequestedHeartbeatSeconds": 30,
-      "NetworkRecoveryInterval": 30,
+      "NetworkRecoveryInterval": 5,
       "DispatchConsumersAsync": true,
       "AutomaticRecoveryEnabled": true
     },
@@ -1309,7 +1309,7 @@ services.AddOpenTelemetry()
       "PrefetchCount": 50,
       "AutoAck": false,
       "RequestedHeartbeatSeconds": 30,
-      "NetworkRecoveryInterval": 30,
+      "NetworkRecoveryInterval": 5,
       "DispatchConsumersAsync": true,
       "AutomaticRecoveryEnabled": true
     }

--- a/src/Trade360SDK.Feed.RabbitMQ/Trade360SDK.Feed.RabbitMQ.csproj
+++ b/src/Trade360SDK.Feed.RabbitMQ/Trade360SDK.Feed.RabbitMQ.csproj
@@ -12,7 +12,7 @@
 			- 2.2.0 Enhanced JSON deserialization with case-insensitive property matching and camel case naming policy support. Improved exception logging in MessageProcessor.
 			- 2.3.0 Added optional RabbitMQ TLS via SslEnabled (set Port to the TLS listener, e.g. 5671).
 			- 2.4.0 Added optional CustomQueueName for the RabbitMQ consumer queue (default _{PackageId}_); validation for queue names on RmqConnectionSettings.
-			- 2.4.1 NetworkRecoveryInterval validation allows 5-4294967 seconds (previous floor was effectively 16). Default remains 30s (TRGN-4200).
+			- 2.4.1 NetworkRecoveryInterval validation allows 0-4294967 seconds; sample 5s; default remains 30s (TRGN-4200).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/src/Trade360SDK.Feed.RabbitMQ/Validators/RmqConnectionSettingsValidator.cs
+++ b/src/Trade360SDK.Feed.RabbitMQ/Validators/RmqConnectionSettingsValidator.cs
@@ -7,9 +7,9 @@ namespace Trade360SDK.Feed.RabbitMQ.Validators
     public static class RmqConnectionSettingsValidator
     {
         /// <summary>
-        /// Minimum allowed NetworkRecoveryInterval in seconds (matches customer-tunable floor of 5s).
+        /// Minimum allowed NetworkRecoveryInterval in seconds (0 = immediate retry).
         /// </summary>
-        public const int MinNetworkRecoveryIntervalSeconds = 5;
+        public const int MinNetworkRecoveryIntervalSeconds = 0;
 
         /// <summary>
         /// Maximum allowed NetworkRecoveryInterval in seconds so TimeSpan-based recovery

--- a/src/Trade360SDK.Feed/Configuration/RmqConnectionSettings.cs
+++ b/src/Trade360SDK.Feed/Configuration/RmqConnectionSettings.cs
@@ -15,7 +15,7 @@
         public bool AutoAck { get; set; } = true; // Default true;
         public int RequestedHeartbeatSeconds { get; set; } = 30; // Default 30 seconds
         /// <summary>
-        /// Network recovery interval in seconds. Default 30. Allowed range: 5–4,294,967.
+        /// Network recovery interval in seconds. Default 30. Allowed range: 0–4,294,967. Sample: 5.
         /// </summary>
         public int NetworkRecoveryInterval { get; set; } = 30;
         public bool SslEnabled { get; set; }

--- a/src/Trade360SDK.Feed/Trade360SDK.Feed.csproj
+++ b/src/Trade360SDK.Feed/Trade360SDK.Feed.csproj
@@ -7,7 +7,7 @@
         <PackageReleaseNotes>
             - 2.0.0 Added `TransportMessageHeaders` as part of the `IEntityHandler.ProcessAsync` method signature
             - 2.1.0 RmqConnectionSettings: optional CustomQueueName; queue name is resolved in RabbitMqFeed (default _{PackageId}_)
-            - 2.1.1 NetworkRecoveryInterval default remains 30s; customers may set 5–4,294,967s (TRGN-4200)
+            - 2.1.1 NetworkRecoveryInterval default remains 30s; sample 5s; allowed range 0-4294967s (TRGN-4200)
         </PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Feed.RabbitMQ.Tests/Exceptions/RmqConnectionSettingsValidatorComprehensiveTests.cs
+++ b/test/Trade360SDK.Feed.RabbitMQ.Tests/Exceptions/RmqConnectionSettingsValidatorComprehensiveTests.cs
@@ -459,8 +459,6 @@ public class RmqConnectionSettingsValidatorComprehensiveTests
     }
 
     [Theory]
-    [InlineData(4)]
-    [InlineData(0)]
     [InlineData(-1)]
     [InlineData(int.MaxValue)]
     public void Validate_WithInvalidNetworkRecoveryInterval_ShouldThrowArgumentException(int invalidInterval)
@@ -480,11 +478,12 @@ public class RmqConnectionSettingsValidatorComprehensiveTests
         var act = () => RmqConnectionSettingsValidator.Validate(settings);
 
         act.Should().Throw<ArgumentException>()
-           .WithMessage("NetworkRecoveryInterval must be between 5 and 4294967 seconds.*")
+           .WithMessage("NetworkRecoveryInterval must be between 0 and 4294967 seconds.*")
            .And.ParamName.Should().Be("NetworkRecoveryInterval");
     }
 
     [Theory]
+    [InlineData(0)]
     [InlineData(5)]
     [InlineData(10)]
     [InlineData(16)]

--- a/test/Trade360SDK.Feed.Tests/Configuration/RmqConnectionSettingsValidatorTests.cs
+++ b/test/Trade360SDK.Feed.Tests/Configuration/RmqConnectionSettingsValidatorTests.cs
@@ -199,9 +199,8 @@ public class RmqConnectionSettingsValidatorTests
     }
 
     [Theory]
-    [InlineData(4)]
-    [InlineData(0)]
     [InlineData(-1)]
+    [InlineData(int.MaxValue)]
     public void Validate_WithInvalidNetworkRecoveryInterval_ShouldThrowArgumentException(int networkRecoveryInterval)
     {
         var settings = new RmqConnectionSettings
@@ -218,6 +217,6 @@ public class RmqConnectionSettingsValidatorTests
         Action act = () => RmqConnectionSettingsValidator.Validate(settings);
 
         act.Should().Throw<ArgumentException>()
-           .WithMessage("NetworkRecoveryInterval must be between 5 and 4294967 seconds.*");
+           .WithMessage("NetworkRecoveryInterval must be between 0 and 4294967 seconds.*");
     }
 }

--- a/test/Trade360SDK.Feed.Tests/Configuration/ValidationTests.cs
+++ b/test/Trade360SDK.Feed.Tests/Configuration/ValidationTests.cs
@@ -40,7 +40,7 @@ public class ValidationTests
     [InlineData("localhost", 5672, "/", 1, "user", null, 30, 20)]
     [InlineData("localhost", 5672, "/", 1, "user", "", 30, 20)]
     [InlineData("localhost", 5672, "/", 1, "user", "pass", 5, 20)]
-    [InlineData("localhost", 5672, "/", 1, "user", "pass", 30, 4)]
+    [InlineData("localhost", 5672, "/", 1, "user", "pass", 30, -1)]
     public void RmqConnectionSettingsValidator_WithInvalidSettings_ShouldThrowArgumentException(
         string host, int port, string virtualHost, int packageId, string userName, string password, int heartbeat, int recovery)
     {


### PR DESCRIPTION
# User description
## Summary
- Allow `NetworkRecoveryInterval` of `0` (immediate retry) in addition to positive values up to `4,294,967` seconds
- Keep the property default at `30` seconds for backward compatibility
- Update README samples to `5` seconds (faster recovery guidance from TRGN-4200)
- Align CHANGELOG, package release notes, and validator unit tests

Follow-up to merged #109.

Linear: https://linear.app/lsports-ltd/issue/TRGN-4200/all-sdks-networkrecoveryinterval-interval-change

## Test plan
- [ ] Validator accepts `0` and `5`
- [ ] Validator rejects negatives and values above `4,294,967`
- [ ] Omitted config still defaults to `30`
- [ ] Sample `appsettings` with `NetworkRecoveryInterval: 5` starts the feed


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Allow <code>NetworkRecoveryInterval</code> to accept immediate retry (<code>0</code>) while retaining the <code>30</code>-second default and the upper bound of <code>4,294,967</code> seconds. Update README configuration samples and release documentation to recommend <code>5</code> seconds for faster feed recovery.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/110?tool=ast&topic=Configuration+Guidance>Configuration Guidance</a>
        </td><td>Guide users toward faster recovery by changing sample <code>NetworkRecoveryInterval</code> settings from <code>30</code> to <code>5</code> seconds.<details><summary>Modified files (1)</summary><ul><li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix: allow NetworkReco...</td><td>August 10, 2026</td></tr>
<tr><td>PavelTemno</td><td>Update README.md</td><td>April 02, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/110?tool=ast&topic=Network+Recovery>Network Recovery</a>
        </td><td>Enable faster network recovery by supporting <code>0</code> for immediate retries while preserving backward-compatible defaults and validating the supported range.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix: allow NetworkReco...</td><td>August 10, 2026</td></tr>
<tr><td>gal.be@lsports.eu</td><td>fix: use Array.Empty f...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/110?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>