### PR TITLE
fix: expose NextFixtureStartTime on GetOutrightLeagueEvents (TRGN-4310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Release Version 2.5.11]
+
+### [Trade360SDK.Common.Entities - v2.3.11]
+
+#### Added
+
+- **`OutrightLeagueCompetitionWrapper.NextFixtureStartTime`**: optional next fixture start time on the league `Competition` node for snapshot `GetOutrightLeagueEvents` and `GetOutrightLeagueMarkets` (TRGN-4310). Previously only deserialized on feed type 40 via `OutrightLeagueMarketCompetitionWrapper`.
+
+### Backward Compatibility (v2.5.11)
+
+All changes are backward compatible. `NextFixtureStartTime` is optional and remains `null` when absent from the payload.
+
+---
+
 ## [Release Version 2.5.10]
 
 ### [Trade360SDK.Feed - v2.1.1]

--- a/src/Trade360SDK.Common.Entities/Entities/MessageTypes/OutrightLeagueMarketUpdate.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/MessageTypes/OutrightLeagueMarketUpdate.cs
@@ -11,7 +11,6 @@ namespace Trade360SDK.Common.Entities.MessageTypes
         [JsonConverter(typeof(OutrightLeagueMarketCompetitionWrapperConverter))]
         public OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>? Competition { get; set; }
 
-        public DateTime? GetNextFixtureStartTime() =>
-            (Competition as OutrightLeagueMarketCompetitionWrapper<OutrightLeagueMarketEvent>)?.NextFixtureStartTime;
+        public DateTime? GetNextFixtureStartTime() => Competition?.NextFixtureStartTime;
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueCompetitionWrapper.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueCompetitionWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Trade360SDK.Common.Entities.OutrightLeague
 {
@@ -7,6 +8,7 @@ namespace Trade360SDK.Common.Entities.OutrightLeague
         public int Id { get; set; }
         public string? Name { get; set; }
         public int Type { get; set; }
+        public DateTime? NextFixtureStartTime { get; set; }
         public IEnumerable<OutrightLeagueEventsWrapper<TEvent>>? Competitions { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapper.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapper.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.Generic;
-
 namespace Trade360SDK.Common.Entities.OutrightLeague
 {
     public class OutrightLeagueMarketCompetitionWrapper<TEvent> : OutrightLeagueCompetitionWrapper<TEvent>
     {
-        public DateTime? NextFixtureStartTime { get; set; }
     }
 }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.10</PackageVersion>
+		<PackageVersion>2.3.11</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -28,6 +28,7 @@
 			- 2.3.8 Added MarketPredictionData (volume only) on Market and ProviderMarket, and BetPredictionData (volume, liquidity, startDate, endDate) on BaseBet (PRD-1516).
 			- 2.3.9 Added FeedInterrupted on HeartbeatUpdate (entity 32) for feed interruption signal (TRGN-3934).
 			- 2.3.10 Added FixtureName to OutrightLeagueMarketEvent for message types 40 and 43 (TRGN-1739).
+			- 2.3.11 Added NextFixtureStartTime to OutrightLeagueCompetitionWrapper for snapshot GetOutrightLeagueEvents/GetOutrightLeagueMarkets (TRGN-4310).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/MessageTypes/OutrightLeagueMarketUpdateTests.cs
@@ -71,8 +71,9 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
         }
 
         [Fact]
-        public void GetNextFixtureStartTime_WhenCompetitionIsBaseWrapper_ShouldReturnNull()
+        public void GetNextFixtureStartTime_WhenCompetitionIsBaseWrapper_ShouldReturnNextFixtureStartTime()
         {
+            var nextFixtureStartTime = DateTime.Parse("2026-05-29T14:44:55Z").ToUniversalTime();
             var update = new OutrightLeagueMarketUpdate
             {
                 Competition = new OutrightLeagueCompetitionWrapper<OutrightLeagueMarketEvent>
@@ -80,10 +81,11 @@ namespace Trade360SDK.Common.Tests.Entities.MessageTypes
                     Id = 67,
                     Name = "League_67",
                     Type = 3,
+                    NextFixtureStartTime = nextFixtureStartTime,
                 }
             };
 
-            update.GetNextFixtureStartTime().Should().BeNull();
+            update.GetNextFixtureStartTime().Should().Be(nextFixtureStartTime);
         }
 
         [Fact]

--- a/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueCompetitionWrapperTests.cs
+++ b/test/Trade360SDK.Common.Entities.Tests/Entities/OutrightLeague/OutrightLeagueCompetitionWrapperTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Trade360SDK.Common.Entities.OutrightLeague;
 using Xunit;
@@ -13,16 +14,19 @@ namespace Trade360SDK.Common.Tests
             {
                 new OutrightLeagueEventsWrapper<string> { Id = 1 }
             };
+            var nextFixtureStartTime = new DateTime(2026, 5, 29, 14, 44, 55, DateTimeKind.Utc);
             var wrapper = new OutrightLeagueCompetitionWrapper<string>
             {
                 Id = 5,
                 Name = "CompWrapper",
                 Type = 2,
+                NextFixtureStartTime = nextFixtureStartTime,
                 Competitions = competitions
             };
             Assert.Equal(5, wrapper.Id);
             Assert.Equal("CompWrapper", wrapper.Name);
             Assert.Equal(2, wrapper.Type);
+            Assert.Equal(nextFixtureStartTime, wrapper.NextFixtureStartTime);
             Assert.Equal(competitions, wrapper.Competitions);
         }
 
@@ -31,6 +35,7 @@ namespace Trade360SDK.Common.Tests
         {
             var wrapper = new OutrightLeagueCompetitionWrapper<string>();
             Assert.Null(wrapper.Name);
+            Assert.Null(wrapper.NextFixtureStartTime);
             Assert.Null(wrapper.Competitions);
         }
     }

--- a/test/Trade360SDK.SnapshotApi.Tests/Entities/Responses/GetOutrightLeagueEventsResponseTests.cs
+++ b/test/Trade360SDK.SnapshotApi.Tests/Entities/Responses/GetOutrightLeagueEventsResponseTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Trade360SDK.Common.Entities.OutrightLeague;
 using Trade360SDK.SnapshotApi.Entities.Responses;
 using Xunit;
@@ -158,6 +160,46 @@ namespace Trade360SDK.SnapshotApi.Tests.Entities.Responses
             response.Competition = secondCompetitions;
             Assert.Equal(secondCompetitions, response.Competition);
             Assert.Equal(2, response.Competition.Count());
+        }
+
+        [Fact]
+        public void JsonDeserialization_WithNextFixtureStartTime_ShouldPopulateCompetition()
+        {
+            const string json = """
+                [
+                  {
+                    "Competition": [
+                      {
+                        "Id": 67,
+                        "Name": "League_67",
+                        "Type": 3,
+                        "NextFixtureStartTime": "2026-05-29T14:44:55Z",
+                        "Competitions": [
+                          {
+                            "Id": 2029,
+                            "Name": "Season_2029",
+                            "Type": 4,
+                            "Events": [
+                              { "FixtureId": 26721036 }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """;
+
+            var result = JsonSerializer.Deserialize<GetOutrightLeagueEventsResponse[]>(json);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            var competition = Assert.Single(result![0].Competition);
+            Assert.Equal(67, competition.Id);
+            Assert.Equal("League_67", competition.Name);
+            Assert.Equal(3, competition.Type);
+            Assert.Equal(DateTime.Parse("2026-05-29T14:44:55Z").ToUniversalTime(), competition.NextFixtureStartTime?.ToUniversalTime());
+            Assert.Equal(26721036, competition.Competitions!.Single().Events!.Single().FixtureId);
         }
     }
 }


### PR DESCRIPTION
# User description
## Summary
- Expose optional `NextFixtureStartTime` on `OutrightLeagueCompetitionWrapper` so snapshot `/PreMatch/GetOutrightLeagueEvents` (and `GetOutrightLeagueMarkets`) deserialize the field the API already returns.
- Previously the property existed only on the type-40 feed wrapper, so snapshot JSON dropped it.
- Release **2.5.11** / `Trade360SDK.Common.Entities` **2.3.11**.

## Test plan
- [x] Common.Entities OutrightLeague tests (41 passed)
- [x] SnapshotApi `GetOutrightLeagueEventsResponseTests` JSON round-trip with `NextFixtureStartTime` (7 passed)
- [ ] Confirm against Postman `/PreMatch/GetOutrightLeagueEvents` for fixture `16875885` after package publish


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose optional <code>NextFixtureStartTime</code> through <code>OutrightLeagueCompetitionWrapper</code> so snapshot endpoints <code>GetOutrightLeagueEvents</code> and <code>GetOutrightLeagueMarkets</code> preserve the API-provided value. Update <code>OutrightLeagueMarketUpdate</code> access and document the backward-compatible 2.5.11 release.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/111?tool=ast&topic=Release+documentation>Release documentation</a>
        </td><td>Document the new optional property and its backward-compatible availability in release 2.5.11.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix: expose NextFixtur...</td><td>August 19, 2026</td></tr>
<tr><td>gal.be@lsports.eu</td><td>fix: use Array.Empty f...</td><td>August 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/111?tool=ast&topic=Snapshot+field+support>Snapshot field support</a>
        </td><td>Expose <code>NextFixtureStartTime</code> on the shared competition response model so snapshot JSON deserialization supports the field for outright league events and markets.<details><summary>Modified files (3)</summary><ul><li>src/Trade360SDK.Common.Entities/Entities/MessageTypes/OutrightLeagueMarketUpdate.cs</li>
<li>src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueCompetitionWrapper.cs</li>
<li>src/Trade360SDK.Common.Entities/Entities/OutrightLeague/OutrightLeagueMarketCompetitionWrapper.cs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix: expose NextFixtur...</td><td>August 19, 2026</td></tr>
<tr><td>PavelTemno</td><td>Fix auto-refactor rena...</td><td>August 27, 2024</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/111?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>