### PR TITLE
TR-23341: Feed RefundReason in settlement messages (add RefundReason enum on BaseBet)

### DIFF
--- a/src/Trade360SDK.Common.Entities/Entities/Enums/RefundReason.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Enums/RefundReason.cs
@@ -1,0 +1,15 @@
+namespace Trade360SDK.Common.Entities.Enums
+{
+    public enum RefundReason
+    {
+        NotSet = 0,
+        MarketSettlementRules = 1,
+        EventCancelled = 2,
+        EventAbandoned = 3,
+        PlayerNotPlayed = 4,
+        PlayerNotInLineUp = 5,
+        MinPeriodsNotReached = 6,
+        MinBallsNotReached = 7,
+        NonessentialMarket = 8,
+    }
+}

--- a/src/Trade360SDK.Common.Entities/Entities/Markets/BaseBet.cs
+++ b/src/Trade360SDK.Common.Entities/Entities/Markets/BaseBet.cs
@@ -35,6 +35,8 @@ namespace Trade360SDK.Common.Entities.Markets
         
         public int? SuspensionReason { get; set; }
 
+        public RefundReason? RefundReason { get; set; }
+
         public DateTime LastUpdate { get; set; }
 
         public double? Probability { get; set; }

--- a/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
+++ b/src/Trade360SDK.Common.Entities/Trade360SDK.Common.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<PackageVersion>2.3.11</PackageVersion>
+		<PackageVersion>2.3.12</PackageVersion>
 		<PackageReleaseNotes>
 			- 1.0.2 version includes clock addition to scoreboard model, and playerstatistic addition to livescore model
 			- 1.0.3 Added additional values to StatusDescription Enum (which is part of the ScoreBoard entity).
@@ -29,6 +29,7 @@
 			- 2.3.9 Added FeedInterrupted on HeartbeatUpdate (entity 32) for feed interruption signal (TRGN-3934).
 			- 2.3.10 Added FixtureName to OutrightLeagueMarketEvent for message types 40 and 43 (TRGN-1739).
 			- 2.3.11 Added NextFixtureStartTime to OutrightLeagueCompetitionWrapper for snapshot GetOutrightLeagueEvents/GetOutrightLeagueMarkets (TRGN-4310).
+			- 2.3.12 Added optional RefundReason on BaseBet for settlement refund messages (TR-23341).
 		</PackageReleaseNotes>
 	</PropertyGroup>
 


### PR DESCRIPTION
# User description
## Summary
- Pass DI RefundReason through settlement pipeline (TR-23341)
- Jira: https://lsports-data.atlassian.net/browse/TR-23341

## Test plan
- [ ] Unit tests pass
- [ ] QA settlement with Refund + RefundReason on type 35

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add the <code>RefundReason</code> enum and expose it on <code>BaseBet</code> so settlement processing can carry refund causes through the betting model. Support refund reasons including cancellation, abandonment, lineup status, and minimum-period or ball requirements.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ortal@lsports.eu</td><td>feat(sdk): add RefundR...</td><td>August 24, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>Add InPlay and PreMatc...</td><td>November 19, 2025</td></tr></table></details>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-dotnet-sdk/113?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>